### PR TITLE
dev-util/global: Version bump to 6.3.4 and add ctags support

### DIFF
--- a/dev-util/global/files/50gtags-gentoo.el
+++ b/dev-util/global/files/50gtags-gentoo.el
@@ -1,0 +1,6 @@
+
+;;; global site-lisp configuration
+
+(add-to-list 'load-path "@SITELISP@")
+(autoload 'gtags-mode "gtags"
+  "Toggle Gtags mode, a minor mode for browsing source code using GLOBAL." t)

--- a/dev-util/global/files/global-6.2.9-tinfo.patch
+++ b/dev-util/global/files/global-6.2.9-tinfo.patch
@@ -1,0 +1,28 @@
+diff --git a/m4/check_curses.m4 b/m4/check_curses.m4
+index 14aaec5..dca7c0e 100644
+--- a/m4/check_curses.m4
++++ b/m4/check_curses.m4
+@@ -229,16 +229,17 @@ AC_DEFUN([AC_NCURSES], [
+ ])
+
+ AC_DEFUN([AC_SEARCH_NCURSES], [
++    PKG_CHECK_MODULES(NCURSES,ncurses)
+     AS_MESSAGE(checking "location of ncurses.h file"...)
+
+-    AC_NCURSES(/usr/include, ncurses.h, -lncurses,, "ncurses on /usr/include")
+-    AC_NCURSES(/usr/include/ncurses, ncurses.h, -lncurses, -I/usr/include/ncurses, "ncurses on /usr/include/ncurses")
+-    AC_NCURSES(/usr/local/include, ncurses.h, -L/usr/local/lib -lncurses, -I/usr/local/include, "ncurses on /usr/local")
+-    AC_NCURSES(/usr/local/include/ncurses, ncurses.h, -L/usr/local/lib -L/usr/local/lib/ncurses -lncurses, -I/usr/local/include/ncurses, "ncurses on /usr/local/include/ncurses")
++    AC_NCURSES(/usr/include, ncurses.h, $NCURSES_LIBS,, "ncurses on /usr/include")
++    AC_NCURSES(/usr/include/ncurses, ncurses.h, $NCURSES_LIBS, -I/usr/include/ncurses, "ncurses on /usr/include/ncurses")
++    AC_NCURSES(/usr/local/include, ncurses.h, -L/usr/local/lib $NCURSES_LIBS, -I/usr/local/include, "ncurses on /usr/local")
++    AC_NCURSES(/usr/local/include/ncurses, ncurses.h, -L/usr/local/lib -L/usr/local/lib/ncurses $NCURSES_LIBS, -I/usr/local/include/ncurses, "ncurses on /usr/local/include/ncurses")
+
+-    AC_NCURSES(/usr/local/include/ncurses, curses.h, -L/usr/local/lib -lncurses, -I/usr/local/include/ncurses -DRENAMED_NCURSES, "renamed ncurses on /usr/local/.../ncurses")
++    AC_NCURSES(/usr/local/include/ncurses, curses.h, -L/usr/local/lib $NCURSES_LIBS, -I/usr/local/include/ncurses -DRENAMED_NCURSES, "renamed ncurses on /usr/local/.../ncurses")
+
+-    AC_NCURSES(/usr/include/ncurses, curses.h, -lncurses, -I/usr/include/ncurses -DRENAMED_NCURSES, "renamed ncurses on /usr/include/ncurses")
++    AC_NCURSES(/usr/include/ncurses, curses.h, $NCURSES_LIBS, -I/usr/include/ncurses -DRENAMED_NCURSES, "renamed ncurses on /usr/include/ncurses")
+
+     dnl
+     dnl We couldn't find ncurses, try SysV curses

--- a/dev-util/global/global-6.3.4.ebuild
+++ b/dev-util/global/global-6.3.4.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header:
+
+EAPI="5"
+
+inherit autotools elisp-common eutils
+
+DESCRIPTION="GNU Global is a tag system to find the locations of a specified object in various sources"
+HOMEPAGE="http://www.gnu.org/software/global/global.html"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 ppc x86 ~x86-fbsd"
+IUSE="ctags doc emacs vim"
+
+RDEPEND="|| ( dev-libs/libltdl:0 sys-devel/libtool:2 )
+	sys-libs/ncurses
+	ctags? ( dev-util/ctags )
+	emacs? ( virtual/emacs )
+	vim? ( || ( app-editors/vim app-editors/gvim ) )"
+DEPEND="${DEPEND}
+	doc? ( app-text/texi2html sys-apps/texinfo )"
+
+SITEFILE="50gtags-gentoo.el"
+
+src_prepare() {
+	epatch "${FILESDIR}/${PN}-6.2.9-tinfo.patch"
+	eautoreconf
+}
+
+src_configure() {
+	econf "$(use_with emacs lispdir "${SITELISP}/${PN}")" \
+		"$(use_with ctags exuberant-ctags "/usr/bin/exuberant-ctags")"
+}
+
+src_compile() {
+	if use doc; then
+		texi2pdf -q -o doc/global.pdf doc/global.texi
+		texi2html -o doc/global.html doc/global.texi
+	fi
+
+	if use emacs; then
+		elisp-compile *.el
+	fi
+
+	emake
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	if use doc; then
+		dohtml doc/global.html
+		# doc/global.pdf is generated if tex executable (e.g. /usr/bin/tex) is available.
+		[[ -f doc/global.pdf ]] && dodoc doc/global.pdf
+	fi
+
+	dodoc AUTHORS FAQ NEWS README THANKS
+
+	insinto /etc
+	doins gtags.conf
+
+	if use vim; then
+		insinto /usr/share/vim/vimfiles/plugin
+		doins gtags.vim
+	fi
+
+	if use emacs; then
+		elisp-install ${PN} *.{el,elc}
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
+
+	prune_libtool_files
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}


### PR DESCRIPTION
Add an USE ctags for exuberant-ctags support, which can make gtags use exuberant-ctags as builtin parser to extend language support.
