### PR TITLE
[media-sound/kwplayer]: version bump to 3.5.2

### DIFF
--- a/media-sound/kwplayer/kwplayer-3.4.8.ebuild
+++ b/media-sound/kwplayer/kwplayer-3.4.8.ebuild
@@ -25,6 +25,7 @@ RDEPEND="${DEPEND}
 	media-libs/gst-plugins-base:1.0
 	media-libs/gst-plugins-good:1.0
 	media-libs/gst-plugins-ugly:1.0
+	media-libs/gst-plugins-bad:1.0
 	media-plugins/gst-plugins-libav:1.0
 	x11-themes/gnome-icon-theme
 	x11-themes/gnome-icon-theme-symbolic


### PR DESCRIPTION
Add gst-plugins-bad to dependencies and version bump to 3.5.2.
