### PR TITLE
media-plugins/gimp-gap : add a new ebuild: GIMP animation package

### DIFF
--- a/media-plugins/gimp-gap/Manifest
+++ b/media-plugins/gimp-gap/Manifest
@@ -1,0 +1,1 @@
+DIST gimp-gap-2.6.0.tar.bz2 8503561 SHA256 1483f5e17ed5f9107c1702fcac3b7a66e6834061560ccb449fc4eaca7a3c2cca

--- a/media-plugins/gimp-gap/files/extern_lib_fix.patch
+++ b/media-plugins/gimp-gap/files/extern_lib_fix.patch
@@ -1,0 +1,15 @@
+--- gimp-gap-2.2.0/extern_libs/_Makefile.in	2005-10-28 11:39:26.000000000 -0500
++++ gimp-gap-2.2.0/extern_libs/Makefile.in	2005-11-24 13:49:50.000000000 -0500
+@@ -451,9 +451,9 @@
+ @BUILD_LIBMPEG3_LIB_TRUE@	make
+ 
+ install-data-hook:
+-	rm -f $(GAPLIBDIR)/libavformat.a \
+-	rm -f $(GAPLIBDIR)/libavcodec.a \
+-	rm -f $(GAPLIBDIR)/libmpeg3.a
++	rm -f ${D}$(GAPLIBDIR)/libavformat.a \
++	rm -f ${D}$(GAPLIBDIR)/libavcodec.a \
++	rm -f ${D}$(GAPLIBDIR)/libmpeg3.a
+ 
+ # eof (without this line Makefile generation produces syntax error)
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
+++ b/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2015 Gentoo Technologies, Inc.
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+inherit eutils flag-o-matic
+
+DESCRIPTION="Gimp Animation Package"
+SRC_URI="http://download.gimp.org/pub/gimp/plug-ins/v2.6/gap/${P}.tar.bz2"
+HOMEPAGE="http://www.gimp.org/"
+
+KEYWORDS="~x86 ~amd64 ~ppc"
+SLOT="0"
+LICENSE="GPL-2"
+IUSE="mpeg xanim wavplay sox mp3 mplayer"
+
+DEPEND=">=media-gfx/gimp-2.6
+	mpeg? ( media-libs/xvid )"
+RDEPEND="${DEPEND}
+	wavplay? ( >=media-sound/wavplay-1.4 )
+	mplayer? ( media-video/mplayer )
+	xanim? ( >=media-video/xanim-2.80.1 )
+	sox? ( >=media-sound/sox-12.17 )
+	mp3? ( >=media-sound/lame-3.9 )"
+
+src_compile() {
+	epatch ${FILESDIR}/extern_lib_fix.patch
+	econf --disable-libmpeg3 || die "econf failed"
+	sed -i  's/^LDFLAGS = /LDFLAGS = -lm -lpthread /' gap/Makefile
+	emake || die "emake failed"
+}
+
+src_install() {
+	make DESTDIR=${D} install || die "install failed"
+	dodoc AUTHORS ChangeLog* NEWS README
+	docinto howto
+	dodoc docs/howto/txt/*.txt
+	docinto reference
+	dodoc docs/reference/txt/*.txt
+}


### PR DESCRIPTION
gap(GIMP animation package) is a GIMP plugin. 
e.g. This plugin could help to split gif image to frames.

I got the original ebuild from [here](http://data.gpo.zugaina.org/ibormuth/media-gfx/gimp-gap/).
But it's too old to work, so I made some changes.
