### PR TITLE
sys-apps/linux-misc-apps: allow pmtools >= 20130209

### DIFF
--- a/sys-apps/linux-misc-apps/linux-misc-apps-3.19.ebuild
+++ b/sys-apps/linux-misc-apps/linux-misc-apps-3.19.ebuild
@@ -42,7 +42,7 @@ SRC_URI="${SRC_URI} mirror://kernel/linux/kernel/v3.x/${LINUX_SOURCES}"
 RDEPEND="sys-apps/hwids
 		>=dev-libs/glib-2.6
 		tcpd? ( sys-apps/tcp-wrappers )
-		!sys-power/pmtools"
+		!<sys-power/pmtools-20130209"
 DEPEND="${RDEPEND}
 		virtual/pkgconfig"
 


### PR DESCRIPTION
according to https://github.com/anyc/pmtools/releases/tag/20130209, since pmtools 20130209 all races between these packages were removed
