### PR TITLE
app-antivirus/bitdefender: use new bash-completion-r1.eclass

### DIFF
--- a/app-antivirus/bitdefender-scanner/bitdefender-scanner-7.6.4-r1.ebuild
+++ b/app-antivirus/bitdefender-scanner/bitdefender-scanner-7.6.4-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="2"
 
-inherit bash-completion gnome2-utils rpm versionator
+inherit bash-completion-r1 gnome2-utils rpm versionator
 
 DOWNLOAD_PAGE="http://www.bitdefender.com/site/Downloads/browseEvaluationVersion/2/80/"
 SRC_NAME_BASE="BitDefender-Antivirus-Scanner-$(replace_version_separator 2 '-').linux-gcc4x.ARCH.rpm.run"


### PR DESCRIPTION
remove the deprecated bash-completion warning
