### PR TITLE
sys-kernel/dkms: use bash-completion-r1

### DIFF
--- a/sys-kernel/dkms/dkms-2.2.0.3.ebuild
+++ b/sys-kernel/dkms/dkms-2.2.0.3.ebuild
@@ -2,7 +2,7 @@
 
 EAPI="4"
 
-inherit eutils bash-completion
+inherit eutils bash-completion-r1
 
 DESCRIPTION="Dynamic Kernel Module Support"
 SRC_URI="http://linux.dell.com/dkms/permalink/${P}.tar.gz"


### PR DESCRIPTION
remove the deprecated bash-completion warning
