### PR TITLE
一个 KDE 下的 Markdown 编辑器兼笔记软件：app-editors/marketo

### DIFF
--- a/app-editors/marketo/marketo-9999.ebuild
+++ b/app-editors/marketo/marketo-9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit cmake-utils git-r3
+
+DESCRIPTION=" A note-taking KDE application with the power of lightweight markup language"
+HOMEPAGE="https://github.com/sadhen/marketo"
+EGIT_REPO_URI="https://github.com/sadhen/marketo.git"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND="dev-util/cmake
+	kde-frameworks/kdewebkit
+	kde-frameworks/kfilemetadata
+	kde-frameworks/ktexteditor
+	kde-frameworks/extra-cmake-modules
+	dev-libs/libmdcpp
+	sys-devel/gcc[cxx]
+"
+RDEPEND="${DEPEND}"

--- a/dev-libs/libmdcpp/libmdcpp-9999.ebuild
+++ b/dev-libs/libmdcpp/libmdcpp-9999.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit cmake-utils git-r3
+
+DESCRIPTION="implementation of the Markdown markup language in CPP (library)"
+HOMEPAGE="https://github.com/sadhen/libmdcpp/"
+EGIT_REPO_URI="https://github.com/sadhen/libmdcpp.git"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND="dev-util/cmake
+	dev-libs/boost
+	sys-devel/gcc[cxx]
+"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
A note-taking KDE application with the power of lightweight markup language

项目地址在这：[sadhen/marketo](https://github.com/sadhen/marketo)
详细的介绍：https://www.v2ex.com/t/243228
