### PR TITLE
kde-misc/plasma-applet-netspeed-widget: add new package

### DIFF
--- a/kde-misc/plasma-applet-netspeed-widget/Manifest
+++ b/kde-misc/plasma-applet-netspeed-widget/Manifest
@@ -1,0 +1,1 @@
+DIST plasma-applet-netspeed-widget-1.3.tar.gz 13626 SHA256 0c7bf32c46410d025dec370e8f5f23f5452c97d7cbff7787b6fdb8ad1feb48cb

--- a/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-1.3.ebuild
+++ b/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-1.3.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit kde5
+
+DESCRIPTION="Plasma 5 widget that displays the currently used network bandwidth."
+HOMEPAGE="https://www.kde-look.org/p/998895/
+https://github.com/HessiJames/plasma-applet-netspeed-widget"
+
+if [[ ${KDE_BUILD_TYPE} = live ]] ; then
+	EGIT_REPO_URI="https://github.com/HessiJames/${PN}.git"
+else
+	SRC_URI="https://github.com/HessiJames/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+fi
+
+LICENSE="GPL-2+"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep plasma)
+"
+RDEPEND="${DEPEND}"
+
+DOCS=( README.md )

--- a/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-9999.ebuild
+++ b/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-9999.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit kde5
+
+DESCRIPTION="Plasma 5 widget that displays the currently used network bandwidth."
+HOMEPAGE="https://www.kde-look.org/p/998895/
+https://github.com/HessiJames/plasma-applet-netspeed-widget"
+
+if [[ ${KDE_BUILD_TYPE} = live ]] ; then
+	EGIT_REPO_URI="https://github.com/HessiJames/${PN}.git"
+else
+	SRC_URI="https://github.com/HessiJames/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+fi
+
+LICENSE="GPL-2+"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep plasma)
+"
+RDEPEND="${DEPEND}"
+
+DOCS=( README.md )


### PR DESCRIPTION
Plasma 5 widget that displays the currently used network bandwidth.
Homepage: https://www.kde-look.org/p/998895/

![Screen shot of plasma-applet-netspeed-widget](https://raw.githubusercontent.com/HessiJames/plasma-applet-netspeed-widget/master/netspeed-widget.png)
