### PR TITLE
Add docker-swarm-1.2.5.

### DIFF
--- a/app-emulation/docker-swarm/Manifest
+++ b/app-emulation/docker-swarm/Manifest
@@ -1,0 +1,1 @@
+DIST docker-swarm-1.2.5.tar.gz 4619026 SHA256 d3f20d94525ff9b338a0d31feaed6a9779801bcadf23ffc33e5ce4a3ad106beb

--- a/app-emulation/docker-swarm/docker-swarm-1.2.5.ebuild
+++ b/app-emulation/docker-swarm/docker-swarm-1.2.5.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+EGO_PN=github.com/docker/${PN##*-}/...
+
+if [[ ${PV} = *9999* ]]; then
+	inherit golang-vcs
+else
+	KEYWORDS="~amd64"
+	EGIT_COMMIT="v${PV}"
+	SRC_URI="https://${EGO_PN%/*}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+	inherit golang-vcs-snapshot
+fi
+inherit golang-build
+
+DESCRIPTION="A Docker-native clustering system"
+HOMEPAGE="https://docs.docker.com/${PN##*-}/"
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+RESTRICT="test"
+DEPEND=">=dev-lang/go-1.6:=
+	!!<app-admin/consul-0.6.3-r1"
+RDEPEND=""
+S=${WORKDIR}/${P}/src/${EGO_PN%/*}
+
+src_compile() {
+	GOPATH="${WORKDIR}/${P}:${S}/vendor:$(get_golibdir_gopath)" \
+		go install -v -work -x ${EGO_BUILD_FLAGS} "${EGO_PN%/*}" || die
+}
+
+src_install() {
+	dobin "${WORKDIR}/${P}/bin/${PN#docker-}"
+	dosym swarm /usr/bin/docker-swarm
+	dodoc CHANGELOG.md CONTRIBUTING.md README.md ROADMAP.md
+}


### PR DESCRIPTION
由于新版本的 `godep` [更改了 workspace 的位置](https://github.com/tools/godep/tree/3c0ccb9a2415fbda40b982b622735906bcd1760f#migrating-to-vendor)，导致 `::gentoo` 中的 ebuild 脚本从 `1.2.1-rc1` 版本以后就没法成功构建了（也可能是这个原因 `app-emulation/docker-swarm::gentoo` 之后就没更新过）。

我已经给这个 ebuild 已经打了补丁，可以正常构建。
