### PR TITLE
fix opencv3 dependencies for nixnote

### DIFF
--- a/app-misc/nixnote/metadata.xml
+++ b/app-misc/nixnote/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>atenzd@gmail.com</email>
+		<name>Aten Zhang</name>
+	</maintainer>
+	<use>
+		<flag name="opencv3">Use media-libs/opencv:0/3.0 for WebCam instead media-libs/opencv:0/2.4</flag>
+		<flag name="hunspell">Enable spellchecking plugin using app-text/hunspell</flag>
+		<flag name="webcam">Enable WebCam plugin</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">nixnote2</remote-id>
+		<bugs-to>https://github.com/baumgarr/nixnote2/issues</bugs-to>
+	</upstream>
+</pkgmetadata>

--- a/app-misc/nixnote/nixnote-2.0.9999.ebuild
+++ b/app-misc/nixnote/nixnote-2.0.9999.ebuild
@@ -22,14 +22,12 @@ HOMEPAGE="http://sourceforge.net/projects/nevernote/"
 
 LICENSE="GPL-2"
 [[ ${PV} == *9999* ]] || KEYWORDS="~amd64 ~x86"
-IUSE="qt4 qt5 +opencv3 plugins"
+IUSE="qt4 qt5 opencv3 hunspell webcam"
 
-REQUIRED_USE="^^ ( qt4 qt5 )
-		      qt5? ( opencv3 )
-		      "
+REQUIRED_USE="^^ ( qt4 qt5 )"
 
 DEPEND="dev-libs/boost
-	      app-text/hunspell
+		  net-misc/curl
 	      
 	      qt4? (
 		      app-text/poppler[qt4]
@@ -44,31 +42,34 @@ DEPEND="dev-libs/boost
 		      dev-qt/qtcore:5
 		      dev-qt/qtgui:5
 		      dev-qt/qtsql:5
+			  dev-qt/qtxml:5
+			  dev-qt/qtnetwork:5
+			  dev-qt/qtwidgets:5
+			  dev-qt/qtprintsupport:5
+			  dev-qt/qtdbus:5
 	      )
+
+		  hunspell? ( app-text/hunspell )
 		  
-		  opencv3? ( =media-libs/opencv-3* )
-		  !opencv3? ( media-libs/opencv:0/2.4 )
-	      "
+		  webcam?  (
+		  	  opencv3? ( >=media-libs/opencv-3.0.0:0= )
+		      !opencv3? ( <media-libs/opencv-3.0.0:0= )
+		  )
+		"
 RDEPEND="${DEPEND}
 		app-text/htmltidy"
-
-# After commit 836482e, NixNote2 can not be compiled with qt4 any more
-#if [[ "${PV}" == *9999* ]] && use qt4; then
-#	EGIT_COMMIT="836482e00c93618560c2896bbac87d3f89d17299"
-#fi
 
 src_prepare() {
 
 	# fix VideoCapture undefined reference error with opencv-3
-	if use opencv3; then
-		sed -i 's/LIBS += /LIBS +=  -lopencv_videoio/g' NixNote2.pro
-		sed -i '/\#include "opencv\/cv.h"/i\#include "opencv2\/videoio.hpp"' dialog/webcamcapturedialog.h
-	fi
-	
-	if use qt4; then
-		sed -i 's|Q_PLUGIN_METADATA|// Q_PLUGIN_METADATA|g' plugins/webcam/webcamplugin.h 
-		sed -i 's|Q_PLUGIN_METADATA|// Q_PLUGIN_METADATA|g' plugins/hunspell/hunspellplugin.h   
-	fi
+#	if use opencv3; then
+#		sed -i '/\#include "opencv\/cv.h"/i\#include "opencv2\/videoio.hpp"' dialog/webcamcapturedialog.h
+#	fi
+#	
+#	if use qt4; then
+#		sed -i 's|Q_PLUGIN_METADATA|// Q_PLUGIN_METADATA|g' plugins/webcam/webcamplugin.h 
+#		sed -i 's|Q_PLUGIN_METADATA|// Q_PLUGIN_METADATA|g' plugins/hunspell/hunspellplugin.h   
+#	fi
 	
 	lupdate -pro NixNote2.pro -no-obsolete || die
 	lrelease NixNote2.pro || die
@@ -79,10 +80,13 @@ src_configure() {
 	if use qt4; then
 		eqmake4 NixNote2.pro
 
-		if use plugins; then
+		if use hunspell; then
 			cd ${S}/plugins/hunspell
 			eqmake4 Hunspell.pro
 	
+			cd ${S}
+		fi
+		if use webcam; then
 			cd ${S}/plugins/webcam
 			eqmake4 WebCam.pro
 
@@ -92,10 +96,13 @@ src_configure() {
 	if use qt5; then
 		eqmake5 NixNote2.pro
 		
-		if use plugins; then
+		if use hunspell; then
 			cd ${S}/plugins/hunspell
 			eqmake5 Hunspell.pro
 
+			cd ${S}
+		fi
+		if use webcam; then
 			cd ${S}/plugins/webcam
 			eqmake5 WebCam.pro
 
@@ -107,10 +114,13 @@ src_configure() {
 src_compile() {
 	emake || die "build Nixnote failed"
 
-	if use plugins; then
+	if use hunspell; then
 		cd ${S}/plugins/hunspell
 		emake || die "plugin Hunspell build failed"
 
+		cd ${S}
+	fi
+	if use webcam; then
 		cd ${S}/plugins/webcam
 		emake || die "plugin WebCam build failed"
 		
@@ -124,10 +134,14 @@ src_install() {
 
 	rm -r ${D}/usr/share/nixnote2/translations/*.ts
 	
-	if use plugins; then
+	if use hunspell; then
 		insinto /usr/share/nixnote2/plugins
-		doins plugins/libhunspellplugin.so plugins/libwebcamplugin.so
+		doins plugins/libhunspellplugin.so
 		fperms 0755 /usr/share/nixnote2/plugins/libhunspellplugin.so
+	fi
+	if use webcam; then
+		insinto /usr/share/nixnote2/plugins
+		doins plugins/libwebcamplugin.so
 		fperms 0755 /usr/share/nixnote2/plugins/libwebcamplugin.so
 	fi
 	dobin nixnote2

--- a/app-misc/nixnote/nixnote-2.0.9999.ebuild
+++ b/app-misc/nixnote/nixnote-2.0.9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="http://sourceforge.net/projects/nevernote/"
 
 LICENSE="GPL-2"
 [[ ${PV} == *9999* ]] || KEYWORDS="~amd64 ~x86"
-IUSE="qt4 qt5 +opencv3"
+IUSE="qt4 qt5 +opencv3 plugins"
 
 REQUIRED_USE="^^ ( qt4 qt5 )
 		      qt5? ( opencv3 )
@@ -46,7 +46,7 @@ DEPEND="dev-libs/boost
 		      dev-qt/qtsql:5
 	      )
 		  
-		  opencv3? ( media-libs/opencv:0/3.0 )
+		  opencv3? ( =media-libs/opencv-3* )
 		  !opencv3? ( media-libs/opencv:0/2.4 )
 	      "
 RDEPEND="${DEPEND}
@@ -73,20 +73,63 @@ src_prepare() {
 	lupdate -pro NixNote2.pro -no-obsolete || die
 	lrelease NixNote2.pro || die
 	
+}
+
+src_configure() {
 	if use qt4; then
 		eqmake4 NixNote2.pro
+
+		if use plugins; then
+			cd ${S}/plugins/hunspell
+			eqmake4 Hunspell.pro
+	
+			cd ${S}/plugins/webcam
+			eqmake4 WebCam.pro
+
+			cd ${S}
+		fi
 	fi
 	if use qt5; then
 		eqmake5 NixNote2.pro
+		
+		if use plugins; then
+			cd ${S}/plugins/hunspell
+			eqmake5 Hunspell.pro
+
+			cd ${S}/plugins/webcam
+			eqmake5 WebCam.pro
+
+			cd ${S}
+		fi
 	fi
 }
 
+src_compile() {
+	emake || die "build Nixnote failed"
+
+	if use plugins; then
+		cd ${S}/plugins/hunspell
+		emake || die "plugin Hunspell build failed"
+
+		cd ${S}/plugins/webcam
+		emake || die "plugin WebCam build failed"
+		
+		cd ${S}
+	fi
+
+}
 src_install() {
 	insinto /usr/share/nixnote2
 	doins -r  help images java qss translations changelog.txt license.html shortcuts.txt *.ini
 
 	rm -r ${D}/usr/share/nixnote2/translations/*.ts
 	
+	if use plugins; then
+		insinto /usr/share/nixnote2/plugins
+		doins plugins/libhunspellplugin.so plugins/libwebcamplugin.so
+		fperms 0755 /usr/share/nixnote2/plugins/libhunspellplugin.so
+		fperms 0755 /usr/share/nixnote2/plugins/libwebcamplugin.so
+	fi
 	dobin nixnote2
 	
 	insinto /usr/share/applications

--- a/app-misc/nixnote/nixnote-2.0_beta10.ebuild
+++ b/app-misc/nixnote/nixnote-2.0_beta10.ebuild
@@ -15,7 +15,7 @@ else
 	S="${WORKDIR}/${PN}2-${MY_PV}"
 fi
 
-SLOT="2"   
+SLOT="2" 
 DESCRIPTION="Nixnote - A clone of Evernote for Linux"
 HOMEPAGE="http://sourceforge.net/projects/nevernote/"
 
@@ -26,7 +26,7 @@ IUSE="qt4 qt5 +opencv3"
 REQUIRED_USE="^^ ( qt4 qt5 )
 		      qt5? ( opencv3 )
 		      "
-		
+
 DEPEND="dev-libs/boost
 	      app-text/hunspell
 	      
@@ -36,8 +36,6 @@ DEPEND="dev-libs/boost
 		      dev-qt/qtcore:4
 		      dev-qt/qtgui:4
 		      dev-qt/qtsql:4
-		      opencv3? ( media-libs/opencv:0/3.0[qt4] )
-		      !opencv3? ( media-libs/opencv:0/2.4[qt4] )
 	      )
 	      qt5? (
 		      app-text/poppler[qt5]
@@ -45,8 +43,9 @@ DEPEND="dev-libs/boost
 		      dev-qt/qtcore:5
 		      dev-qt/qtgui:5
 		      dev-qt/qtsql:5
-		      media-libs/opencv[qt5]
 	      )
+		  opencv3? ( =media-libs/opencv-3* )
+		  !opencv3? ( media-libs/opencv:0/2.4 )
 	      "
 RDEPEND="${DEPEND}
 		app-text/htmltidy"


### PR DESCRIPTION
After the synchronization of major gentoo portage tree recently, the package opencv change one of the SLOTs from "0/3.0" to "0/3.1". So the dependencies of nixnote became invalid. As the nixnote can build against both opencv-3.0 and opencv-3.1. I do a stupid modification that I just change the dependence to "=media-libs/opencv-3*" to match both two SLOTs of opencv. 

If there is a better way to handle this issue, please tell me.