### PR TITLE
dev-python/evernote-sdk-python: fix incorrect eutils v5

### DIFF
--- a/dev-python/evernote-sdk-python/evernote-sdk-python-9999.ebuild
+++ b/dev-python/evernote-sdk-python/evernote-sdk-python-9999.ebuild
@@ -3,8 +3,9 @@
 # $Header: $
 
 EAPI=5
+PYTHON_COMPAT=( python2_7 )
 
-inherit python distutils-r1 git-2
+inherit python-r1 distutils-r1 git-2
 
 DESCRIPTION="Evernote SDK for Python"
 HOMEPAGE="http://dev.evernote.com"


### PR DESCRIPTION
Today after a portage tree update I saw error messages appearing. Looking up the following page:

https://wiki.gentoo.org/wiki/Project:Python/Python.eclass_conversion

I did the necessary changes for the error messages to disappear and the ebuild be inline with the page's recommendations.