### PR TITLE
修复 README.md 中的标题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#rule no.1
+# rule no.1
 
 DO NOT BREAK PEOPLE'S SYSTEM
 
-#rule no.2
+# rule no.2
 
 DO NOT BREAK PEOPLE'S SYSTEM
 
-#rule no.3
+# rule no.3
 
 follow rule no.1 and no.2
 
-#commit message
+# commit message
 
 * for non-version bump commit, commit message should be like this:
 
@@ -26,7 +26,7 @@ follow rule no.1 and no.2
 
         [category/package]: version bump to [new version]
 
-#package review
+# package review
 
 * I trust contributors that have commit rights, therefore commitors
   should think carfully before committing.


### PR DESCRIPTION
之前 README.md 中的标题现在在 GitHub 上渲染不正确……