### PR TITLE
app-i18n/librime: add missing dependency for -9999

### DIFF
--- a/app-i18n/librime/librime-9999.ebuild
+++ b/app-i18n/librime/librime-9999.ebuild
@@ -19,6 +19,7 @@ RDEPEND="
 	dev-cpp/glog
 	>=dev-cpp/yaml-cpp-0.5.0
 	dev-db/kyotocabinet
+	dev-libs/leveldb
 	>=dev-libs/boost-1.46.0
 	dev-libs/marisa
 	sys-libs/zlib


### PR DESCRIPTION
`dev-libs/leveldb` is required since `app-i18n/librime-1.2.9`.

Refer to gentoo portage tree.