### PR TITLE
app-misc/icdiff: add an updated version of icdiff.

### DIFF
--- a/app-misc/icdiff/Manifest
+++ b/app-misc/icdiff/Manifest
@@ -1,0 +1,1 @@
+DIST icdiff-1.9.0.tar.gz 23069 SHA256 ef64fda913c21be229e1ed967c577edcfc917543293c3bbd6d1a5775a84471cb

--- a/app-misc/icdiff/icdiff-1.9.0.ebuild
+++ b/app-misc/icdiff/icdiff-1.9.0.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=(python2_7 python3_4 python3_5)
+
+inherit distutils-r1
+
+DESCRIPTION="Colourized diff that supports side-by-side diffing"
+HOMEPAGE="http://www.jefftk.com/icdiff"
+SRC_URI="https://github.com/jeffkaufman/${PN}/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="PSF-2"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DOCS=(README.md ChangeLog)
+
+S="${WORKDIR}/${PN}-release-${PV}"


### PR DESCRIPTION
Added since Gentoo's one doesn't update.

ebuild was taken from Gentoo's tree, however test part and a patch for test are removed.

Signed-off-by: Wenxuan Zhao <viz@linux.com>