### PR TITLE
Fix missing `python.eclass'.

### DIFF
--- a/app-i18n/sunpinyin-frontend/sunpinyin-frontend-9999.ebuild
+++ b/app-i18n/sunpinyin-frontend/sunpinyin-frontend-9999.ebuild
@@ -2,25 +2,26 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=4
-PYTHON_DEPEND="ibus? 2:2.5"
-inherit confutils git-2 python scons-utils
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit git-2 python-single-r1 scons-utils
 
 DESCRIPTION="IME frontends for Sunpinyin"
 HOMEPAGE="https://code.google.com/p/sunpinyin/"
+EGIT_PROJECT="sunpinyin"
+EGIT_REPO_URI="https://github.com/sunpinyin/sunpinyin.git"
 
 LICENSE="LGPL-2.1 CDDL"
 SLOT="0"
 KEYWORDS=""
 IUSE_FRONTEND="ibus xim"
 IUSE="${IUSE_FRONTEND} nls"
-
-EGIT_PROJECT="sunpinyin"
-EGIT_REPO_URI="https://github.com/sunpinyin/sunpinyin.git"
+REQUIRED_USE="|| ( ${IUSE_FRONTEND} )"
 
 RDEPEND="
 	dev-db/sqlite:3
 	ibus? (
+		${PYTHON_DEPS}
 		>=app-i18n/ibus-1.1
 		!app-i18n/ibus-sunpinyin
 	)
@@ -35,11 +36,6 @@ DEPEND="${RDEPEND}
 	dev-util/scons
 	nls? ( sys-devel/gettext )
 	xim? ( x11-proto/xproto )"
-
-pkg_setup() {
-	confutils_require_any ibus xim
-	python_pkg_setup
-}
 
 src_configure() {
 	myesconsargs=(
@@ -68,14 +64,9 @@ src_install() {
 }
 
 pkg_postinst() {
-	use ibus && python_mod_optimize /usr/share/ibus-sunpinyin/setup
 	if use xim ; then
 		elog "To use sunpinyin with XIM, you should use the following"
 		elog "in your user startup scripts such as .xinitrc or .xprofile:"
 		elog "XMODIFIERS=@im=xsunpinyin ; export XMODIFIERS"
 	fi
-}
-
-pkg_postrm() {
-	use ibus && python_mod_cleanup /usr/share/ibus-sunpinyin/setup
 }

--- a/dev-libs/dtk-widget/dtk-widget-0.5.20130617042230.ebuild
+++ b/dev-libs/dtk-widget/dtk-widget-0.5.20130617042230.ebuild
@@ -2,11 +2,10 @@
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 
-EAPI="4"
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit fdo-mime versionator eutils python-single-r1
 
-inherit fdo-mime versionator eutils python
-
-PYTHON_DEPEND=2:2.7
 MY_VER="$(get_version_component_range 1-2)+git$(get_version_component_range 3)~2491552186"
 SRC_URI="http://packages.linuxdeepin.com/deepin/pool/main/d/${PN}/${PN}_${MY_VER}.tar.gz"
 
@@ -22,16 +21,12 @@ RDEPEND="dev-libs/gobject-introspection
 		dev-libs/glib:2
 		x11-libs/gdk-pixbuf:2
 		x11-libs/gtk+:2
-		dev-lang/python:2.7
-		dev-python/pygobject:2
-		dev-python/pygtk:2"
+		dev-python/pygobject:2[${PYTHON_USEDEP}]
+		dev-python/pygtk:2[${PYTHON_USEDEP}]
+		${PYTHON_DEPS}"
 DEPEND="${RDEPEND}
 		dev-util/gtk-doc"
 S="${WORKDIR}/${PN}-${MY_VER}"
-
-pkg_setup() {
-	python_set_active_version 2.7
-}
 
 src_prepare() {
 	./autogen.sh --prefix=/usr

--- a/dev-python/dtk-widget/dtk-widget-0.5.20130617042230.ebuild
+++ b/dev-python/dtk-widget/dtk-widget-0.5.20130617042230.ebuild
@@ -2,11 +2,10 @@
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 
-EAPI="4"
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit fdo-mime versionator eutils python-single-r1
 
-inherit fdo-mime versionator eutils python
-
-PYTHON_DEPEND=2:2.7
 MY_VER="$(get_version_component_range 1-2)+git$(get_version_component_range 3)~2491552186"
 SRC_URI="http://packages.linuxdeepin.com/deepin/pool/main/d/${PN}/${PN}_${MY_VER}.tar.gz"
 
@@ -23,17 +22,13 @@ RDEPEND="dev-libs/gobject-introspection
 		x11-libs/gdk-pixbuf:2
 		x11-libs/gtk+:2
 		dev-libs/dtk-widget
-		dev-lang/python:2.7
-		dev-python/pygobject:2
-		dev-python/pygtk:2"
+		dev-python/pygobject:2[${PYTHON_USEDEP}]
+		dev-python/pygtk:2[${PYTHON_USEDEP}]
+		${PYTHON_DEPS}"
 DEPEND="${RDEPEND}
 		dev-python/setuptools"
 S="${WORKDIR}/${PN}-${MY_VER}"
 
-pkg_setup() {
-	python_set_active_version 2.7
-}
-
 src_install() {
-	python setup.py install --root=${D}
+	"${PYTHON}" setup.py install --root=${D}
 }

--- a/dev-python/google-appengine/google-appengine-1.7.4.ebuild
+++ b/dev-python/google-appengine/google-appengine-1.7.4.ebuild
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=4
-
-inherit python
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit python-single-r1
 
 DESCRIPTION="Google App Engine SDK for Python"
 HOMEPAGE="http://appengine.google.com/"
@@ -16,21 +16,20 @@ KEYWORDS="~amd64 ~x86"
 IUSE="examples"
 
 RDEPEND="
-	dev-python/mysql-python
-	dev-python/lxml
-	dev-python/imaging
-	dev-python/numpy
-	dev-python/pycrypto
-	dev-python/django
-	dev-python/jinja
-	dev-python/markupsafe
-	dev-python/pyopenssl
-	dev-python/pyyaml
-	dev-python/webob
+	dev-python/mysql-python[${PYTHON_USEDEP}]
+	dev-python/lxml[${PYTHON_USEDEP}]
+	dev-python/imaging[${PYTHON_USEDEP}]
+	dev-python/numpy[${PYTHON_USEDEP}]
+	dev-python/pycrypto[${PYTHON_USEDEP}]
+	dev-python/django[${PYTHON_USEDEP}]
+	dev-python/jinja[${PYTHON_USEDEP}]
+	dev-python/markupsafe[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+	dev-python/webob[${PYTHON_USEDEP}]
 	media-libs/libpng:1.2
+	${PYTHON_DEPS}
 "
-
-PYTHON_DEPEND="2"
 
 S="${WORKDIR}/${PN/-/_}"
 

--- a/dev-python/pystorm/pystorm-0.1.20130426091936.ebuild
+++ b/dev-python/pystorm/pystorm-0.1.20130426091936.ebuild
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 
-EAPI="4"
-
-inherit fdo-mime versionator eutils python
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit fdo-mime versionator eutils python-single-r1
 
 MY_VER="$(get_version_component_range 1-2)+git$(get_version_component_range 3)"
 SRC_URI="http://packages.linuxdeepin.com/deepin/pool/main/p/${PN}/${PN}_${MY_VER}.tar.gz"
@@ -17,18 +17,13 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-RDEPEND="dev-lang/python:2.7
-		dev-python/gevent"
+RDEPEND="${PYTHON_DEPS}
+		dev-python/gevent[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
-		dev-python/setuptools
-		dev-util/intltool"
+		dev-python/setuptools[${PYTHON_USEDEP}]
+		dev-util/intltool[${PYTHON_USEDEP}]"
 S=${WORKDIR}/${PN}-${MY_VER}
 
-pkg_setup() {
-	python_set_active_version 2.7
-}
-
 src_install() {
-
-	python setup.py install --root=${D} || die "Install failed"
+	"${PYTHON}" setup.py install --root=${D} || die "Install failed"
 }

--- a/dev-python/xappy/xappy-0.5.ebuild
+++ b/dev-python/xappy/xappy-0.5.ebuild
@@ -2,12 +2,11 @@
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 
-EAPI="4"
-
-inherit fdo-mime python
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit fdo-mime python-single-r1
 
 SRC_URI="https://${PN}.googlecode.com/files/${P}.tar.gz"
-
 DESCRIPTION="An easy-to-use interface to the Xapian search engine"
 HOMEPAGE="http://code.google.com/p/xappy"
 
@@ -16,15 +15,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-RDEPEND=">=dev-lang/python-2.2
-		dev-libs/xapian-bindings[python]"
+RDEPEND="${PYTHON_DEPS}
+		dev-libs/xapian-bindings[python,${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}"
 
-pkg_setup() {
-	python_set_active_version 2
-}
-
 src_install() {
-
-	python setup.py install --root=${D} || die "Install failed"
+	"${PYTHON}" setup.py install --root=${D} || die "Install failed"
 }

--- a/net-misc/xunlei-lixian/xunlei-lixian-9999.ebuild
+++ b/net-misc/xunlei-lixian/xunlei-lixian-9999.ebuild
@@ -2,14 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=4
-PYTHON_DEPEND=2
-
-inherit python git-2
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+inherit python-single-r1 git-2
 
 DESCRIPTION="Download scripts for xunlei vip users"
 HOMEPAGE="https://github.com/iambus/xunlei-lixian"
-
 EGIT_REPO_URI="https://github.com/iambus/xunlei-lixian.git"
 EGIT_BRANCH="master"
 
@@ -18,10 +16,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-pkg_setup() {
-	python_set_active_version 2
-	python_pkg_setup
-}
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="${PYTHON_DEPS}"
 
 src_prepare() {
 	python_convert_shebangs -r $(python_get_version) .
@@ -36,12 +32,4 @@ src_install() {
 	dosym "$(python_get_sitedir)"/${PN}/lixian_cli.py /usr/bin/${PN}-cli || die
 	dosym "$(python_get_sitedir)"/${PN}/lixian_hash.py /usr/bin/${PN}-hash || die
 	dosym "$(python_get_sitedir)"/${PN}/lixian_batch.py /usr/bin/${PN}-batch || die
-}
-
-pkg_postinst() {
-	python_mod_optimize ${PN}
-}
-
-pkg_postrm() {
-	python_mod_cleanup ${PN}
 }

--- a/net-proxy/goagent/goagent-3.2.2.ebuild
+++ b/net-proxy/goagent/goagent-3.2.2.ebuild
@@ -17,7 +17,9 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-inherit ${GOAGENT_ECLASS} fdo-mime python systemd
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="ssl(+)"
+inherit ${GOAGENT_ECLASS} fdo-mime python-single-r1 systemd
 
 DESCRIPTION="A GAE proxy forked from gappproxy/wallproxy"
 HOMEPAGE="https://github.com/goagent/goagent"
@@ -27,13 +29,13 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="+gtk systemd"
 
-RDEPEND="dev-python/pycrypto
-	dev-lang/python:2.7[ssl]
-	dev-python/pygeoip
+RDEPEND="${PYTHON_DEPS}
+	dev-python/pycrypto[${PYTHON_USEDEP}]
+	dev-python/pygeoip[${PYTHON_USEDEP}]
 	dev-libs/nss[utils]
-	>=dev-python/gevent-1.0
-	dev-python/pyopenssl
-	gtk? ( x11-libs/vte:0[python] )
+	>=dev-python/gevent-1.0[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]
+	gtk? ( x11-libs/vte:0[python,${PYTHON_USEDEP}] )
 	net-libs/pacparser"
 
 src_unpack() {

--- a/net-proxy/goagent/goagent-9999.ebuild
+++ b/net-proxy/goagent/goagent-9999.ebuild
@@ -17,7 +17,9 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-inherit ${GOAGENT_ECLASS} fdo-mime python systemd
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="ssl(+)"
+inherit ${GOAGENT_ECLASS} fdo-mime python-single-r1 systemd
 
 DESCRIPTION="A GAE proxy forked from gappproxy/wallproxy"
 HOMEPAGE="https://github.com/goagent/goagent"
@@ -27,13 +29,13 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="+gtk systemd"
 
-RDEPEND="dev-python/pycrypto
-	dev-lang/python:2.7[ssl]
-	dev-python/pygeoip
+RDEPEND="${PYTHON_DEPS}
+	dev-python/pycrypto[${PYTHON_USEDEP}]
+	dev-python/pygeoip[${PYTHON_USEDEP}]
 	dev-libs/nss[utils]
-	>=dev-python/gevent-1.0
-	dev-python/pyopenssl
-	gtk? ( x11-libs/vte:0[python] )
+	>=dev-python/gevent-1.0[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]
+	gtk? ( x11-libs/vte:0[python,${PYTHON_USEDEP}] )
 	net-libs/pacparser"
 
 src_unpack() {

--- a/net-proxy/wallproxy-plus/wallproxy-plus-2.1.18-r1.ebuild
+++ b/net-proxy/wallproxy-plus/wallproxy-plus-2.1.18-r1.ebuild
@@ -17,10 +17,9 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-PYTHON_DEPEND="2"
-PYTHON_USE_WITH="ssl"
-
-inherit ${WALLPROXY_ECLASS} python systemd
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="ssl(+)"
+inherit ${WALLPROXY_ECLASS} python-single-r1 systemd
 
 DESCRIPTION="New version of wallproxy, a general purpose proxy framework in Python."
 HOMEPAGE="https://github.com/wallproxy/wallproxy"
@@ -30,9 +29,10 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/nss[utils]
-	dev-python/gevent
-	dev-python/pyopenssl"
+RDEPEND="${PYTHON_DEPS}
+	dev-libs/nss[utils]
+	dev-python/gevent[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]"
 
 src_unpack() {
 	${WALLPROXY_ECLASS}_src_unpack

--- a/net-proxy/wallproxy-plus/wallproxy-plus-2.1.19.ebuild
+++ b/net-proxy/wallproxy-plus/wallproxy-plus-2.1.19.ebuild
@@ -17,10 +17,9 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-PYTHON_DEPEND="2"
-PYTHON_USE_WITH="ssl"
-
-inherit ${WALLPROXY_ECLASS} python systemd
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="ssl(+)"
+inherit ${WALLPROXY_ECLASS} python-single-r1 systemd
 
 DESCRIPTION="New version of wallproxy, a general purpose proxy framework in Python."
 HOMEPAGE="https://github.com/wallproxy/wallproxy"
@@ -30,9 +29,10 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/nss[utils]
-	dev-python/gevent
-	dev-python/pyopenssl"
+RDEPEND="${PYTHON_DEPS}
+	dev-libs/nss[utils]
+	dev-python/gevent[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]"
 
 src_unpack() {
 	${WALLPROXY_ECLASS}_src_unpack

--- a/net-proxy/wallproxy-plus/wallproxy-plus-9999.ebuild
+++ b/net-proxy/wallproxy-plus/wallproxy-plus-9999.ebuild
@@ -17,10 +17,9 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-PYTHON_DEPEND="2"
-PYTHON_USE_WITH="ssl"
-
-inherit ${WALLPROXY_ECLASS} python systemd
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="ssl(+)"
+inherit ${WALLPROXY_ECLASS} python-single-r1 systemd
 
 DESCRIPTION="New version of wallproxy, a general purpose proxy framework in Python."
 HOMEPAGE="https://github.com/wallproxy/wallproxy"
@@ -30,9 +29,10 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/nss[utils]
-	dev-python/gevent
-	dev-python/pyopenssl"
+RDEPEND="${PYTHON_DEPS}
+	dev-libs/nss[utils]
+	dev-python/gevent[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]"
 
 src_unpack() {
 	${WALLPROXY_ECLASS}_src_unpack


### PR DESCRIPTION
Done according to https://wiki.gentoo.org/wiki/Project:Python/Python.eclass_conversion.
This fixes `python.eclass could not be found by inherit()` with affected packages.
BTW, the reason for b508ca9f is actually EAPI bump (microcai/gentoo-zh#442); sorry for that mistake.