### PR TITLE
app-misc/nixnote: fix QT5 build

### DIFF
--- a/app-misc/nixnote/nixnote-2.0.2.ebuild
+++ b/app-misc/nixnote/nixnote-2.0.2.ebuild
@@ -48,6 +48,7 @@ DEPEND="dev-libs/boost
 			  dev-qt/qtprintsupport:5
 			  dev-qt/qtdbus:5
 			  dev-qt/qtdeclarative:5
+			  dev-qt/linguist-tools:5
 	      )
 
 		  hunspell? ( app-text/hunspell )

--- a/app-misc/nixnote/nixnote-2.0.9999.ebuild
+++ b/app-misc/nixnote/nixnote-2.0.9999.ebuild
@@ -48,6 +48,7 @@ DEPEND="dev-libs/boost
 			  dev-qt/qtprintsupport:5
 			  dev-qt/qtdbus:5
 			  dev-qt/qtdeclarative:5
+			  dev-qt/linguist-tools:5
 	      )
 
 		  hunspell? ( app-text/hunspell )


### PR DESCRIPTION
Without `dev-qt/linguist-tools` build with USE `qt5` will fail with an error:

```
lupdate: could not exec '/usr/lib64/qt5/bin/lupdate': No such file or directory
```

My system was missing it, so I think it should be an explicit dependency :)