### PR TITLE
Fix dependency for fcitx5

### DIFF
--- a/app-i18n/fcitx5/fcitx5-20191104.ebuild
+++ b/app-i18n/fcitx5/fcitx5-20191104.ebuild
@@ -27,7 +27,7 @@ RDEPEND="dev-libs/glib:2
 	sys-apps/util-linux
 	virtual/libiconv
 	virtual/libintl
-	x11-libs/libxkbcommon
+	x11-libs/libxkbcommon[X]
 	x11-libs/libX11
 	dev-libs/wayland
 	dev-libs/wayland-protocols
@@ -37,7 +37,7 @@ RDEPEND="dev-libs/glib:2
 	x11-libs/libxkbfile
 	x11-libs/xcb-imdkit
 	x11-misc/xkeyboard-config
-	x11-libs/cairo[X]
+	x11-libs/cairo[X,xcb]
 	x11-libs/libXext
 	x11-libs/pango
 	media-libs/fontconfig


### PR DESCRIPTION
Fcitx5 need X USE flag of libxkbcommon and xcb USE flag of cairo