### PR TITLE
Bump required cmake version, move to BDEPEND

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-1.9.3.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-1.9.3.ebuild
@@ -35,6 +35,7 @@ IUSE="crashreporter custom-api-id +pulseaudio +spell test"
 # due to missing WITHOUT_PULSE in Telegram/cmake/lib_tgvoip.cmake:
 REQUIRED_USE="pulseaudio"
 
+BDEPEND=">=dev-util/cmake-3.16" 
 RDEPEND="
 	app-arch/lz4
 	app-arch/xz-utils
@@ -61,7 +62,6 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
-CMAKE_MIN_VERSION="3.8"
 
 PATCHES=( "${FILESDIR}/patches" )
 


### PR DESCRIPTION
Building fails with "CMake 3.16 or higher is required.  You are running version 3.14.6", IRC says support for CMAKE_MIN_VERSION is going away (and it wouldn't work until placing it above inherit cmake-utils)