### PR TITLE
Fix EAPI=7 is not supported problem and git-2 DEPRECATED problem

### DIFF
--- a/app-i18n/fcitx-rime/fcitx-rime-9999.ebuild
+++ b/app-i18n/fcitx-rime/fcitx-rime-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit cmake-utils git-2
+inherit cmake-utils git-r3
 
 DESCRIPTION="Rime Support for Fcitx"
 HOMEPAGE="http://code.google.com/p/rimeime/"

--- a/app-i18n/fcitx-table-extra/fcitx-table-extra-0.3.4.ebuild
+++ b/app-i18n/fcitx-table-extra/fcitx-table-extra-0.3.4.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/fcitx/fcitx-table-extra.git"
 	FCITX_TABLE_EXTRA_SRC_URI=""
-	FCITX_TABLE_EXTRA_ECLASS="git-2"
+	FCITX_TABLE_EXTRA_ECLASS="git-r3"
 	KEYWORDS=""
 else
 	FCITX_TABLE_EXTRA_SRC_URI="http://download.fcitx-im.org/${PN}/${P}.tar.xz"

--- a/app-i18n/fcitx-table-extra/fcitx-table-extra-9999.ebuild
+++ b/app-i18n/fcitx-table-extra/fcitx-table-extra-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/fcitx/fcitx-table-extra.git"
 	FCITX_TABLE_EXTRA_SRC_URI=""
-	FCITX_TABLE_EXTRA_ECLASS="git-2"
+	FCITX_TABLE_EXTRA_ECLASS="git-r3"
 	KEYWORDS=""
 else
 	FCITX_TABLE_EXTRA_SRC_URI="http://fcitx.googlecode.com/files/${P}.tar.xz"

--- a/app-i18n/fcitx/fcitx-9999.ebuild
+++ b/app-i18n/fcitx/fcitx-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit multilib multilib-build cmake-utils eutils gnome2-utils fdo-mime
 
 if [[ ${PV} == "9999" ]]; then
-	inherit git-2
+	inherit git-r3
 fi
 
 if [[ ${PV} == "9999" ]]; then

--- a/app-i18n/ibus-rime/ibus-rime-9999.ebuild
+++ b/app-i18n/ibus-rime/ibus-rime-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="Rime Input Method Engine for IBus Framework"
 HOMEPAGE="http://code.google.com/p/rimeime/"

--- a/app-i18n/ibus-t9/ibus-t9-2.1.0.20100601.ebuild
+++ b/app-i18n/ibus-t9/ibus-t9-2.1.0.20100601.ebuild
@@ -9,7 +9,7 @@ TAR_SUFFIX="tar.gz"
 inherit eutils autotools googlecode
 
 if [ "${PV##*.}" = "9999" ]; then
-	inherit git-2
+	inherit git-r3
 fi
 
 DESCRIPTION="T9 input engine using ibus"

--- a/app-i18n/rime-data/rime-data-9999.ebuild
+++ b/app-i18n/rime-data/rime-data-9999.ebuild
@@ -5,7 +5,7 @@
 EAPI=7
 
 S=${WORKDIR}/brise
-inherit git-2
+inherit git-r3
 EGIT_REPO_URI="https://github.com/lotem/brise.git"
 
 DESCRIPTION="Brise, data resource for Rime Input Method Engine"

--- a/app-misc/geeknote/geeknote-9999.ebuild
+++ b/app-misc/geeknote/geeknote-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit bash-completion-r1 eutils distutils-r1 git-2
+inherit bash-completion-r1 eutils distutils-r1 git-r3
 
 DESCRIPTION="Console client for Evernote"
 HOMEPAGE="http://geeknote.me"

--- a/app-misc/jshon/jshon-9999.ebuild
+++ b/app-misc/jshon/jshon-9999.ebuild
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="Jshon is a JSON parser designed for maximum convenience within the shell"
 HOMEPAGE="http://kmkeen.com/jshon/"

--- a/app-pda/ipadcharge/ipadcharge-9999.ebuild
+++ b/app-pda/ipadcharge/ipadcharge-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit git-2 eutils
+inherit git-r3 eutils
 
 DESCRIPTION="Enables USB charging for Apple devices."
 HOMEPAGE="https://github.com/mkorenkov/ipad_charge"

--- a/app-text/openyoudao/openyoudao-9999.ebuild
+++ b/app-text/openyoudao/openyoudao-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="openyoudao is a youdao client for linux."
 HOMEPAGE="http://openyoudao.org"

--- a/app-text/wiznote/wiznote-2.1.14.ebuild
+++ b/app-text/wiznote/wiznote-2.1.14.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="${EGIT_MASTER}" 
 	KEYWORDS=""
 	WIZNOTE_SRC_URI=""
-	WIZNOTE_ECLASS="git-2"
+	WIZNOTE_ECLASS="git-r3"
 else
 	WIZNOTE_SRC_URI="https://github.com/WizTeam/WizQTClient/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/app-text/wiznote/wiznote-2.4.0.ebuild
+++ b/app-text/wiznote/wiznote-2.4.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="${EGIT_MASTER}" 
 	KEYWORDS=""
 	WIZNOTE_SRC_URI=""
-	WIZNOTE_ECLASS="git-2"
+	WIZNOTE_ECLASS="git-r3"
 else
 	WIZNOTE_SRC_URI="https://github.com/WizTeam/WizQTClient/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/app-text/wiznote/wiznote-9999.ebuild
+++ b/app-text/wiznote/wiznote-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="${EGIT_MASTER}" 
 	KEYWORDS=""
 	WIZNOTE_SRC_URI=""
-	WIZNOTE_ECLASS="git-2"
+	WIZNOTE_ECLASS="git-r3"
 else
 	WIZNOTE_SRC_URI="https://github.com/WizTeam/WizQTClient/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/app-vim/powerline/powerline-9999.ebuild
+++ b/app-vim/powerline/powerline-9999.ebuild
@@ -3,7 +3,7 @@
 # $Header: $
 
 #VIM_PLUGIN_VIM_VERSION="7.0"
-inherit git-2 vim-plugin
+inherit git-r3 vim-plugin
 
 DESCRIPTION="vim plugin: The ultimate vim statusline utility."
 HOMEPAGE="http://www.vim.org/scripts/script.php?script_id=3881"

--- a/app-vim/powerline/powerline-9999.ebuild
+++ b/app-vim/powerline/powerline-9999.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
+EAPI=7
+
 #VIM_PLUGIN_VIM_VERSION="7.0"
 inherit git-r3 vim-plugin
 

--- a/dev-ruby/mruby/mruby-9999.ebuild
+++ b/dev-ruby/mruby/mruby-9999.ebuild
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="mruby is the lightweight implementation of the Ruby language complying to (part of) the ISO standard."
 HOMEPAGE="https://github.com/mruby/mruby"

--- a/dev-util/be/be-9999.ebuild
+++ b/dev-util/be/be-9999.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils distutils-r1 bash-completion-r1
 
 if [[ "${PV}" == "9999" ]] ; then
-	inherit git-2
+	inherit git-r3
 	EGIT_BRANCH="master"
 	EGIT_REPO_URI="git://gitorious.org/be/be.git"
 	SRC_URI=""
@@ -43,7 +43,7 @@ DEPEND="${RDEPEND}
 
 src_unpack() {
 	if [[ "${PV}" == "9999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 	else
 		unpack "${A}"
 	fi

--- a/dev-util/fernflower/fernflower-1.ebuild
+++ b/dev-util/fernflower/fernflower-1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 
 inherit eutils versionator
 

--- a/dev-util/rinse/rinse-9999.ebuild
+++ b/dev-util/rinse/rinse-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="RPM based distributions bootstrap scripts"
 HOMEPAGE="http://collab-maint.alioth.debian.org/rinse/"

--- a/games-arcade/stepmania/stepmania-5.9999.ebuild
+++ b/games-arcade/stepmania/stepmania-5.9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit games autotools eutils git-2
+inherit games autotools eutils git-r3
 
 DESCRIPTION="Stepmania 5 sm-ssc branch"
 HOMEPAGE="https://github.com/stepmania/stepmania"

--- a/media-gfx/sane-backends/sane-backends-9999.ebuild
+++ b/media-gfx/sane-backends/sane-backends-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit eutils flag-o-matic git-2
+inherit eutils flag-o-matic git-r3
 
 # gphoto and v4l are handled by their usual USE flags.
 # The pint backend was disabled because I could not get it to compile.

--- a/media-libs/MonkVG/MonkVG-9999.ebuild
+++ b/media-libs/MonkVG/MonkVG-9999.ebuild
@@ -5,7 +5,7 @@
 EAPI=7
 AUTOTOOLS_IN_SOURCE_BUILD=1
 
-inherit git-2 autotools-utils
+inherit git-r3 autotools-utils
 
 DESCRIPTION="MonkVG is an OpenVG 1.1 like vector graphics API implementation
 currently using an OpenGL ES backend"

--- a/media-libs/libspiro/libspiro-0.3.20150131.ebuild
+++ b/media-libs/libspiro/libspiro-0.3.20150131.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools-multilib
+inherit autotools
 
 DESCRIPTION="Spiro is the creation of Raph Levien. It simplifies the drawing of beautiful curves."
 HOMEPAGE="https://github.com/fontforge/libspiro"

--- a/media-plugins/osdlyrics/osdlyrics-9999.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit eutils autotools versionator git-2
+inherit eutils autotools versionator git-r3
 
 HOMEPAGE="http://code.google.com/p/osd-lyrics/"
 

--- a/media-sound/deadbeef/deadbeef-0.5.1-r3.ebuild
+++ b/media-sound/deadbeef/deadbeef-0.5.1-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 
 inherit fdo-mime gnome2 eutils
 

--- a/media-sound/deadbeef/deadbeef-9999.ebuild
+++ b/media-sound/deadbeef/deadbeef-9999.ebuild
@@ -3,7 +3,7 @@
 # $Header: $
 
 
-inherit autotools git-2
+inherit autotools git-r3
 
 DESCRIPTION="mp3/ogg/flac/sid/mod/nsf music player based on GTK2"
 HOMEPAGE="http://deadbeef.sourceforge.net/"

--- a/media-video/avplayer/avplayer-9999.ebuild
+++ b/media-video/avplayer/avplayer-9999.ebuild
@@ -3,7 +3,7 @@
 # $Header: $
 
 EAPI=5
-inherit cmake-utils git-2
+inherit cmake-utils git-r3
 
 DESCRIPTION="avplayer is a p2p video downloader and player"
 HOMEPAGE="http://avplayer.avplayer.org"

--- a/media-video/simplescreenrecorder/simplescreenrecorder-0.3.3-r1.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-0.3.3-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=7
 inherit autotools flag-o-matic multilib-minimal
 
 if [[ ${PV} = 9999 ]]; then
-	inherit git-2
+	inherit git-r3
 fi
 
 DESCRIPTION="A Simple Screen Recorder"

--- a/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=7
 inherit autotools flag-o-matic multilib-minimal
 
 if [[ ${PV} = 9999 ]]; then
-	inherit git-2
+	inherit git-r3
 fi
 
 DESCRIPTION="A Simple Screen Recorder"

--- a/net-libs/jzmq/jzmq-9999.ebuild
+++ b/net-libs/jzmq/jzmq-9999.ebuild
@@ -7,7 +7,7 @@ HOMEPAGE="http://www.zeromq.org/bindings:java"
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/zeromq/jzmq.git"
-	vcs=git-2
+	vcs=git-r3
 else
 	SRC_URI=""
 	KEYWORDS="~amd64 ~x86"

--- a/net-misc/avsocks/avsocks-9999.ebuild
+++ b/net-misc/avsocks/avsocks-9999.ebuild
@@ -8,7 +8,7 @@ DESCRIPTION="科学操长城软件"
 HOMEPAGE="https://github.com/avplayer/avsocks"
 SRC_URI=""
 
-inherit cmake-utils git-2
+inherit cmake-utils git-r3
 
 EGIT_REPO_URI="https://github.com/avplayer/avsocks.git"
 

--- a/net-misc/networkmanager-l2tp/networkmanager-l2tp-9999.ebuild
+++ b/net-misc/networkmanager-l2tp/networkmanager-l2tp-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit eutils gnome.org git-2 autotools
+inherit eutils gnome.org git-r3 autotools
 
 # NetworkManager likes itself with capital letters
 MY_PN="${PN/networkmanager/NetworkManager}"

--- a/net-misc/you-get/you-get-9999.ebuild
+++ b/net-misc/you-get/you-get-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_3 python3_4 python3_5 python3_6 )
 
-inherit eutils distutils-r1 git-2
+inherit eutils distutils-r1 git-r3
 
 DESCRIPTION="A video downloader for YouTube, Youku, niconico and a few other sites"
 HOMEPAGE="http://www.soimort.org/you-get"

--- a/net-p2p/amule-dlp-antileech/amule-dlp-antileech-9999.ebuild
+++ b/net-p2p/amule-dlp-antileech/amule-dlp-antileech-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools git-2 wxwidgets
+inherit autotools git-r3 wxwidgets
 DESCRIPTION="$PN, dynamic DLP library for amule-dlp"
 HOMEPAGE="https://github.com/persmule/amule-dlp.antileech"
 EGIT_REPO_URI="https://github.com/persmule/amule-dlp.antiLeech.git"

--- a/net-p2p/amule-dlp/amule-dlp-9999.ebuild
+++ b/net-p2p/amule-dlp/amule-dlp-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools eutils flag-o-matic wxwidgets user git-2
+inherit autotools eutils flag-o-matic wxwidgets user git-r3
 
 
 DESCRIPTION="aMule with DLP patch, the all-platform eMule p2p client"

--- a/net-proxy/goagent/goagent-3.2.2.ebuild
+++ b/net-proxy/goagent/goagent-3.2.2.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="3.0"
 	KEYWORDS=""
 	GOAGENT_SRC_URI=""
-	GOAGENT_ECLASS="git-2"
+	GOAGENT_ECLASS="git-r3"
 else
 	GOAGENT_SRC_URI="https://github.com/goagent/goagent/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/net-proxy/goagent/goagent-9999.ebuild
+++ b/net-proxy/goagent/goagent-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="3.0"
 	KEYWORDS=""
 	GOAGENT_SRC_URI=""
-	GOAGENT_ECLASS="git-2"
+	GOAGENT_ECLASS="git-r3"
 else
 	GOAGENT_SRC_URI="https://github.com/goagent/goagent/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/net-proxy/shadowsocks/shadowsocks-9999.ebuild
+++ b/net-proxy/shadowsocks/shadowsocks-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils distutils-r1 git-2
+inherit eutils distutils-r1 git-r3
 
 DESCRIPTION=" A fast tunnel proxy that helps you bypass firewalls"
 HOMEPAGE="http://shadowsocks.org/"

--- a/net-proxy/shadowvpn/shadowvpn-9999.ebuild
+++ b/net-proxy/shadowvpn/shadowvpn-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit eutils git-2
+inherit eutils git-r3
 
 DESCRIPTION="A fast, safe VPN based on libsodium"
 HOMEPAGE="http://shadowvpn.org/"

--- a/net-proxy/wallproxy-plus/wallproxy-plus-2.1.18-r1.ebuild
+++ b/net-proxy/wallproxy-plus/wallproxy-plus-2.1.18-r1.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="${EGIT_MASTER}" 
 	KEYWORDS=""
 	WALLPROXY_SRC_URI=""
-	WALLPROXY_ECLASS="git-2"
+	WALLPROXY_ECLASS="git-r3"
 else
 	WALLPROXY_SRC_URI="https://github.com/wallproxy/wallproxy/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/net-proxy/wallproxy-plus/wallproxy-plus-2.1.19.ebuild
+++ b/net-proxy/wallproxy-plus/wallproxy-plus-2.1.19.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="${EGIT_MASTER}" 
 	KEYWORDS=""
 	WALLPROXY_SRC_URI=""
-	WALLPROXY_ECLASS="git-2"
+	WALLPROXY_ECLASS="git-r3"
 else
 	WALLPROXY_SRC_URI="https://github.com/wallproxy/wallproxy/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/net-proxy/wallproxy-plus/wallproxy-plus-9999.ebuild
+++ b/net-proxy/wallproxy-plus/wallproxy-plus-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_BRANCH="${EGIT_MASTER}" 
 	KEYWORDS=""
 	WALLPROXY_SRC_URI=""
-	WALLPROXY_ECLASS="git-2"
+	WALLPROXY_ECLASS="git-r3"
 else
 	WALLPROXY_SRC_URI="https://github.com/wallproxy/wallproxy/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	RESTRICT="mirror"

--- a/sci-libs/libticables2/libticables2-9999.ebuild
+++ b/sci-libs/libticables2/libticables2-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools eutils git-2
+inherit autotools eutils git-r3
 
 DESCRIPTION="Library to handle different link cables for TI calculators"
 HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"

--- a/sci-libs/libticalcs2/libticalcs2-9999.ebuild
+++ b/sci-libs/libticalcs2/libticalcs2-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools eutils git-2
+inherit autotools eutils git-r3
 
 DESCRIPTION="Library for communication with TI calculators"
 HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"

--- a/sci-libs/libticonv/libticonv-9999.ebuild
+++ b/sci-libs/libticonv/libticonv-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools eutils git-2
+inherit autotools eutils git-r3
 
 DESCRIPTION="Charset conversion library for TI calculators"
 HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"

--- a/sci-libs/libtifiles2/libtifiles2-9999.ebuild
+++ b/sci-libs/libtifiles2/libtifiles2-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools eutils git-2
+inherit autotools eutils git-r3
 
 DESCRIPTION="Library for TI calculator files"
 HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"

--- a/sys-apps/mdp/mdp-9999.ebuild
+++ b/sys-apps/mdp/mdp-9999.ebuild
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="A command-line based markdown presentation tool"
 HOMEPAGE="https://github.com/visit1985/mdp"

--- a/sys-apps/uksmstat/uksmstat-9999.ebuild
+++ b/sys-apps/uksmstat/uksmstat-9999.ebuild
@@ -3,7 +3,7 @@
 # $Header: $
 
 EAPI=7
-inherit git-2
+inherit git-r3
 DESCRIPTION="Small tool to show UKSM statistics."
 HOMEPAGE="https://github.com/pfactum/uksmstat"
 EGIT_REPO_URI="https://github.com/pfactum/uksmstat.git"

--- a/sys-fs/f2fs-tools/f2fs-tools-9999.ebuild
+++ b/sys-fs/f2fs-tools/f2fs-tools-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit autotools git-2
+inherit autotools git-r3
 
 DESCRIPTION="Tools for Flash-Friendly File System (F2FS)"
 HOMEPAGE="http://sourceforge.net/projects/f2fs-tools/"

--- a/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999-r1.ebuild
+++ b/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 
 EGIT_REPO_URI="https://github.com/zfsonlinux/${PN}.git"
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="Automatic snapshots for ZFS on Linux"
 HOMEPAGE="https://github.com/dajhorn/zfs-auto-snapshot/"

--- a/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999.ebuild
+++ b/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999.ebuild
@@ -6,7 +6,7 @@
 
 EAPI=7
 
-inherit eutils git-2
+inherit eutils git-r3
 
 DESCRIPTION="An alternative implementation of the zfs-auto-snapshot service for Linux"
 HOMEPAGE="https://github.com/zfsonlinux/zfs-auto-snapshot"

--- a/sys-kernel/e-sources/e-sources-3.18.14.ebuild
+++ b/sys-kernel/e-sources/e-sources-3.18.14.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 K_DEBLOB_AVAILABLE="1"
 
 ck_version="1"

--- a/sys-kernel/e-sources/e-sources-4.0.9.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.0.9.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 K_DEBLOB_AVAILABLE="1"
 
 ck_version="1"

--- a/sys-kernel/e-sources/e-sources-4.1.12.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.1.12.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 K_DEBLOB_AVAILABLE="1"
 
 ck_version="2"

--- a/sys-kernel/e-sources/e-sources-4.2.5.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.2.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 K_DEBLOB_AVAILABLE="1"
 
 ck_version=""

--- a/sys-kernel/e-sources/e-sources-4.5.2.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.5.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=7
+EAPI=6
 K_DEBLOB_AVAILABLE="0"
 K_KDBUS_AVAILABLE="1"
 

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.29.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.29.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=6
 
 ETYPE="sources"
 K_WANT_GENPATCHES="base"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.44.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.44.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=6
 
 ETYPE="sources"
 K_WANT_GENPATCHES="base"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.52.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.52.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=6
 
 ETYPE="sources"
 K_WANT_GENPATCHES="base"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.65.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.65.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=6
 
 ETYPE="sources"
 K_WANT_GENPATCHES="base"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.74.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.74.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=6
 
 ETYPE="sources"
 K_WANT_GENPATCHES="base"

--- a/virtual/linux-sources/linux-sources-1.ebuild
+++ b/virtual/linux-sources/linux-sources-1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Virtual for Linux kernel sources"
 HOMEPAGE=""

--- a/x11-libs/libvdpau-va-gl/libvdpau-va-gl-9999.ebuild
+++ b/x11-libs/libvdpau-va-gl/libvdpau-va-gl-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=7
 
-inherit cmake-utils multilib git-2
+inherit cmake-utils multilib git-r3
 
 DESCRIPTION="VDPAU driver with VA-API/OpenGL backend."
 HOMEPAGE="https://github.com/i-rinat/libvdpau-va-gl/"


### PR DESCRIPTION
* Fix git-2 DEPRECATED problem
  * git-2 is DEPRECATED. Please use git-r3 instead.
  * git-2.eclass: Ban for EAPI=6
  * git-2.eclass: Ban for EAPI=7
* app-vim/powerline: fix obsolete EAPI
* kernel: Fix kernel-2: EAPI 7 not supported

Package-Manager: Portage-2.3.82, Repoman-2.3.20