### PR TITLE
app-i18n/fcitx5-configtool: Fix missing RDEPEND if kcm USE is not set

### DIFF
--- a/app-i18n/fcitx5-configtool/fcitx5-configtool-5.0.0.ebuild
+++ b/app-i18n/fcitx5-configtool/fcitx5-configtool-5.0.0.ebuild
@@ -34,6 +34,9 @@ RDEPEND="app-i18n/fcitx5
         kde-frameworks/kirigami:5
         kde-frameworks/kdeclarative:5
 	)
+	!kcm? (
+		dev-qt/qtdeclarative
+	)
     config-qt? (
         kde-frameworks/kitemviews:5
     )

--- a/app-i18n/fcitx5-configtool/fcitx5-configtool-99999999.ebuild
+++ b/app-i18n/fcitx5-configtool/fcitx5-configtool-99999999.ebuild
@@ -33,6 +33,9 @@ RDEPEND="app-i18n/fcitx5
         kde-frameworks/kirigami:5
         kde-frameworks/kdeclarative:5
 	)
+	!kcm? (
+		dev-qt/qtdeclarative
+	)
     config-qt? (
         kde-frameworks/kitemviews:5
     )


### PR DESCRIPTION
If kcm USE is not set, missing header files result in compilation error.

`/var/tmp/portage/app-i18n/fcitx5-configtool-5.0.0/work/fcitx5-configtool-5.0.0/src/lib/configlib/layoutprovider.cpp:9:10: fatal error: QtQml/qqml.h: No such file or directory`