### PR TITLE
app-i18n/fcitx5-gtk-999999999: disable GTK4 module

### DIFF
--- a/app-i18n/fcitx5-gtk/fcitx5-gtk-999999999.ebuild
+++ b/app-i18n/fcitx5-gtk/fcitx5-gtk-999999999.ebuild
@@ -35,6 +35,7 @@ src_configure() {
 		-DCMAKE_BUILD_TYPE=Release
 		-DENABLE_GTK2_IM_MODULE=$(usex gtk2)
 		-DENABLE_GTK3_IM_MODULE=$(usex gtk3)
+		-DENABLE_GTK4_IM_MODULE=no
 		-DENABLE_SNOOPER=$(usex snooper)
 		-DENABLE_GIR=$(usex introspection)
 	)


### PR DESCRIPTION
Recently GTK4 support has been added to fcitx5-gtk and is enabled by default, making this live ebuild fail to build. Since GTK4 is not yet packaged in Gentoo, we disable this build option.