### PR TITLE
fix pcmanx-gtk2 emerge failed.

### DIFF
--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
@@ -36,6 +36,7 @@ DEPEND="
 src_prepare() {
 	# this flag crashes CTermData::memset16()
 	filter-flags -ftree-vectorize
+	eapply_user
 }
 
 src_configure() {

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
@@ -40,6 +40,7 @@ src_prepare() {
 
 	# this flag crashes CTermData::memset16()
 	filter-flags -ftree-vectorize
+	eapply_user
 }
 
 src_configure() {


### PR DESCRIPTION
With EAPI 6, you must call eapply_user or default if you define src_prepare