### PR TITLE
update copyright and clean cvs header

### DIFF
--- a/acct-group/cockpit-ws/cockpit-ws-0.ebuild
+++ b/acct-group/cockpit-ws/cockpit-ws-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/acct-user/cockpit-ws/cockpit-ws-0.ebuild
+++ b/acct-user/cockpit-ws/cockpit-ws-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-admin/cockpit/cockpit-234.ebuild
+++ b/app-admin/cockpit/cockpit-234.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-admin/eselect-xim/eselect-xim-0.8.ebuild
+++ b/app-admin/eselect-xim/eselect-xim-0.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-admin/eselect-xim/eselect-xim-0.8.ebuild
+++ b/app-admin/eselect-xim/eselect-xim-0.8.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Manages Input Method of X"
 HOMEPAGE="http://www.gentoo.org/"

--- a/app-admin/eselect-xim/eselect-xim-0.9.1.ebuild
+++ b/app-admin/eselect-xim/eselect-xim-0.9.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Manages Input Method of X"
 HOMEPAGE="http://www.gentoo.org/"

--- a/app-admin/eselect-xim/eselect-xim-0.9.1.ebuild
+++ b/app-admin/eselect-xim/eselect-xim-0.9.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-admin/eselect-xim/eselect-xim-0.9.ebuild
+++ b/app-admin/eselect-xim/eselect-xim-0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-admin/eselect-xim/eselect-xim-0.9.ebuild
+++ b/app-admin/eselect-xim/eselect-xim-0.9.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Manages Input Method of X"
 HOMEPAGE="http://www.gentoo.org/"

--- a/app-arch/p7zip-nsis/p7zip-nsis-0.4-r1.ebuild
+++ b/app-arch/p7zip-nsis/p7zip-nsis-0.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-arch/p7zip-nsis/p7zip-nsis-0.4-r1.ebuild
+++ b/app-arch/p7zip-nsis/p7zip-nsis-0.4-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-arch/unzip/unzip-6.10_beta.ebuild
+++ b/app-arch/unzip/unzip-6.10_beta.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-arch/unzip/unzip-6.10_beta.ebuild
+++ b/app-arch/unzip/unzip-6.10_beta.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit eutils toolchain-funcs flag-o-matic

--- a/app-crypt/etoken-sac/etoken-sac-10.3.ebuild
+++ b/app-crypt/etoken-sac/etoken-sac-10.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-crypt/yubico-piv-tool/yubico-piv-tool-1.4.2.ebuild
+++ b/app-crypt/yubico-piv-tool/yubico-piv-tool-1.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-crypt/yubico-piv-tool/yubico-piv-tool-1.4.2.ebuild
+++ b/app-crypt/yubico-piv-tool/yubico-piv-tool-1.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-dicts/stardict-21shijishuangxiangcidian-en-zh-big5/stardict-21shijishuangxiangcidian-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-21shijishuangxiangcidian-en-zh-big5/stardict-21shijishuangxiangcidian-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-21shijishuangxiangcidian-en-zh-big5/stardict-21shijishuangxiangcidian-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-21shijishuangxiangcidian-en-zh-big5/stardict-21shijishuangxiangcidian-en-zh-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"

--- a/app-dicts/stardict-21shijishuangyukejicidian-en-zh-big5/stardict-21shijishuangyukejicidian-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-21shijishuangyukejicidian-en-zh-big5/stardict-21shijishuangyukejicidian-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-21shijishuangyukejicidian-en-zh-big5/stardict-21shijishuangyukejicidian-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-21shijishuangyukejicidian-en-zh-big5/stardict-21shijishuangyukejicidian-en-zh-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"

--- a/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-dictd-elements/stardict-dictd-elements-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-elements/stardict-dictd-elements-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-dictd-elements/stardict-dictd-elements-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-elements/stardict-dictd-elements-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Stardict Dictionary for Gcide.org's Elements's Dictionary"
 DICT_PREFIX="dictd_www.dict.org_"

--- a/app-dicts/stardict-dictd-gazetteer/stardict-dictd-gazetteer-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-gazetteer/stardict-dictd-gazetteer-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Stardict Dictionary for Gcide.org's Gazetteer's Dictionary"
 DICT_PREFIX="dictd_www.dict.org_"

--- a/app-dicts/stardict-dictd-gazetteer/stardict-dictd-gazetteer-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-gazetteer/stardict-dictd-gazetteer-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-dictd-gcide/stardict-dictd-gcide-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-gcide/stardict-dictd-gcide-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-dictd-gcide/stardict-dictd-gcide-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-gcide/stardict-dictd-gcide-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Stardict Dictionary for Gcide.org's Gcide's Dictionary"
 DICT_PREFIX="dictd_www.dict.org_"

--- a/app-dicts/stardict-dictd-hitchcock/stardict-dictd-hitchcock-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-hitchcock/stardict-dictd-hitchcock-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-dictd-hitchcock/stardict-dictd-hitchcock-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-hitchcock/stardict-dictd-hitchcock-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Stardict Dictionary for Gcide.org's Hitchcock's Dictionary"
 DICT_PREFIX="dictd_www.dict.org_"

--- a/app-dicts/stardict-dictd-wn/stardict-dictd-wn-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-wn/stardict-dictd-wn-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Stardict Dictionary for Gcide.org's Wn's Dictionary"
 DICT_PREFIX="dictd_www.dict.org_"

--- a/app-dicts/stardict-dictd-wn/stardict-dictd-wn-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-wn/stardict-dictd-wn-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-dictd-world95/stardict-dictd-world95-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-world95/stardict-dictd-world95-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-dictd-world95/stardict-dictd-world95-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-world95/stardict-dictd-world95-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Stardict Dictionary for Gcide.org's Devil's Dictionary"
 DICT_PREFIX="dictd_www.dict.org_"

--- a/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-kdic-en-zh-big5/stardict-kdic-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-kdic-en-zh-big5/stardict-kdic-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-kdic-en-zh-big5/stardict-kdic-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-kdic-en-zh-big5/stardict-kdic-en-zh-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"

--- a/app-dicts/stardict-langdao-en-zh-big5/stardict-langdao-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-big5/stardict-langdao-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-langdao-en-zh-big5/stardict-langdao-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-big5/stardict-langdao-en-zh-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"

--- a/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-langdao-zh-en-big5/stardict-langdao-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-big5/stardict-langdao-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-langdao-zh-en-big5/stardict-langdao-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-big5/stardict-langdao-zh-en-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="Traditional Chinese (BIG5)"
 TO_LANG="English"

--- a/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-lazyworm-en-zh-big5/stardict-lazyworm-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-lazyworm-en-zh-big5/stardict-lazyworm-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-lazyworm-en-zh-big5/stardict-lazyworm-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-lazyworm-en-zh-big5/stardict-lazyworm-en-zh-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"

--- a/app-dicts/stardict-lazyworm-zh-en-big5/stardict-lazyworm-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-lazyworm-zh-en-big5/stardict-lazyworm-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-lazyworm-zh-en-big5/stardict-lazyworm-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-lazyworm-zh-en-big5/stardict-lazyworm-zh-en-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="Traditional Chinese (BIG5)"
 TO_LANG="English"

--- a/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
+++ b/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-oxford-en-zh-big5/stardict-oxford-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-big5/stardict-oxford-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-oxford-en-zh-big5/stardict-oxford-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-big5/stardict-oxford-en-zh-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"

--- a/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-quick-eng-eng/stardict-quick-eng-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-eng/stardict-quick-eng-eng-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-quick-eng-eng/stardict-quick-eng-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-eng/stardict-quick-eng-eng-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="English"
 TO_LANG="French"

--- a/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-soothill-buddhist-zh-en-big5/stardict-soothill-buddhist-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-soothill-buddhist-zh-en-big5/stardict-soothill-buddhist-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-soothill-buddhist-zh-en-big5/stardict-soothill-buddhist-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-soothill-buddhist-zh-en-big5/stardict-soothill-buddhist-zh-en-big5-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 FROM_LANG="Traditional Chinese (BIG5)"
 TO_LANG="English"

--- a/app-dicts/stardict-wyabdcrealpeopletts/stardict-wyabdcrealpeopletts-1.0.ebuild
+++ b/app-dicts/stardict-wyabdcrealpeopletts/stardict-wyabdcrealpeopletts-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 IUSE=""
 

--- a/app-dicts/stardict-wyabdcrealpeopletts/stardict-wyabdcrealpeopletts-1.0.ebuild
+++ b/app-dicts/stardict-wyabdcrealpeopletts/stardict-wyabdcrealpeopletts-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-editors/visual-studio-code/visual-studio-code-1.52.1.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.52.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-emulation/genymotion-bin/genymotion-bin-2.9.0.ebuild
+++ b/app-emulation/genymotion-bin/genymotion-bin-2.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-emulation/winetricks-zh/winetricks-zh-9999.ebuild
+++ b/app-emulation/winetricks-zh/winetricks-zh-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-i18n/cldr-emoji-annotation/cldr-emoji-annotation-36.12.120191002-r0.ebuild
+++ b/app-i18n/cldr-emoji-annotation/cldr-emoji-annotation-36.12.120191002-r0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-i18n/cldr-emoji-annotation/cldr-emoji-annotation-9999.ebuild
+++ b/app-i18n/cldr-emoji-annotation/cldr-emoji-annotation-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-i18n/dvp/dvp-1.2.1.ebuild
+++ b/app-i18n/dvp/dvp-1.2.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/app-i18n/dvp/dvp-1.2.1.ebuild
+++ b/app-i18n/dvp/dvp-1.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.3.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.3.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P=${P/-/_}
 DESCRIPTION="UCIMF input method support for FbTerm"

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.5.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.5.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P=${P/-/_}
 DESCRIPTION="UCIMF input method support for FbTerm"

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.6.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.6.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.6.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P=${P/-/_}
 DESCRIPTION="UCIMF input method support for FbTerm"

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.7.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.7.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.7.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P=${P/-/_}
 DESCRIPTION="UCIMF input method support for FbTerm"

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.8.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.8.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.8.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P=${P/-/_}
 DESCRIPTION="UCIMF input method support for FbTerm"

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.9.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.9.ebuild
+++ b/app-i18n/fbterm-ucimf/fbterm-ucimf-0.2.9.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P=${P/-/_}
 DESCRIPTION="UCIMF input method support for FbTerm"

--- a/app-i18n/fcitx-unikey/fcitx-unikey-0.2.2.ebuild
+++ b/app-i18n/fcitx-unikey/fcitx-unikey-0.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/fcitx-unikey/fcitx-unikey-0.2.2.ebuild
+++ b/app-i18n/fcitx-unikey/fcitx-unikey-0.2.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/app-i18n/gcin/gcin-2.8.5.ebuild
+++ b/app-i18n/gcin/gcin-2.8.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/gcin/gcin-2.8.5.ebuild
+++ b/app-i18n/gcin/gcin-2.8.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/app-i18n/hime/hime-0.9.10.ebuild
+++ b/app-i18n/hime/hime-0.9.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/hime/hime-0.9.10.ebuild
+++ b/app-i18n/hime/hime-0.9.10.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit eutils toolchain-funcs flag-o-matic

--- a/app-i18n/ibus-googlepinyin/ibus-googlepinyin-0.1.2.ebuild
+++ b/app-i18n/ibus-googlepinyin/ibus-googlepinyin-0.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ibus-googlepinyin/ibus-googlepinyin-0.1.2.ebuild
+++ b/app-i18n/ibus-googlepinyin/ibus-googlepinyin-0.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/app-i18n/ibus-handwrite/ibus-handwrite-2.1.4.ebuild
+++ b/app-i18n/ibus-handwrite/ibus-handwrite-2.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ibus-handwrite/ibus-handwrite-2.1.4.ebuild
+++ b/app-i18n/ibus-handwrite/ibus-handwrite-2.1.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/ibus-rime/ibus-rime-9999.ebuild
+++ b/app-i18n/ibus-rime/ibus-rime-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ibus-rime/ibus-rime-9999.ebuild
+++ b/app-i18n/ibus-rime/ibus-rime-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/ibus-t9/ibus-t9-2.1.0.20100601.ebuild
+++ b/app-i18n/ibus-t9/ibus-t9-2.1.0.20100601.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ibus-t9/ibus-t9-2.1.0.20100601.ebuild
+++ b/app-i18n/ibus-t9/ibus-t9-2.1.0.20100601.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/ibus-xkb/ibus-xkb-1.4.99.20120525.ebuild
+++ b/app-i18n/ibus-xkb/ibus-xkb-1.4.99.20120525.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit autotools

--- a/app-i18n/ibus-xkb/ibus-xkb-1.4.99.20120525.ebuild
+++ b/app-i18n/ibus-xkb/ibus-xkb-1.4.99.20120525.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/jfbterm/jfbterm-0.4.7-r4.ebuild
+++ b/app-i18n/jfbterm/jfbterm-0.4.7-r4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 WANT_AUTOCONF="latest"
 WANT_AUTOMAKE="latest"

--- a/app-i18n/jfbterm/jfbterm-0.4.7-r4.ebuild
+++ b/app-i18n/jfbterm/jfbterm-0.4.7-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/libgooglepinyin/libgooglepinyin-0.1.2.ebuild
+++ b/app-i18n/libgooglepinyin/libgooglepinyin-0.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/libgooglepinyin/libgooglepinyin-0.1.2.ebuild
+++ b/app-i18n/libgooglepinyin/libgooglepinyin-0.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/libpinyin/libpinyin-1.0.0.ebuild
+++ b/app-i18n/libpinyin/libpinyin-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/libpinyin/libpinyin-1.0.0.ebuild
+++ b/app-i18n/libpinyin/libpinyin-1.0.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit autotools eutils

--- a/app-i18n/librime/librime-1.6.1.ebuild
+++ b/app-i18n/librime/librime-1.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2012-2020 Gentoo Authors
+# Copyright 2012-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"

--- a/app-i18n/lunar/lunar-2.2-r4.ebuild
+++ b/app-i18n/lunar/lunar-2.2-r4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils toolchain-funcs
 

--- a/app-i18n/lunar/lunar-2.2-r4.ebuild
+++ b/app-i18n/lunar/lunar-2.2-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/man-pages-zh_CN/man-pages-zh_CN-9999.ebuild
+++ b/app-i18n/man-pages-zh_CN/man-pages-zh_CN-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/app-i18n/man-pages-zh_CN/man-pages-zh_CN-1.5.ebuild,v 1.4 2010/10/19 10:25:16 leio Exp $
 
 EAPI=7
 

--- a/app-i18n/man-pages-zh_CN/man-pages-zh_CN-9999.ebuild
+++ b/app-i18n/man-pages-zh_CN/man-pages-zh_CN-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/app-i18n/man-pages-zh_CN/man-pages-zh_CN-1.5.ebuild,v 1.4 2010/10/19 10:25:16 leio Exp $
 

--- a/app-i18n/rime-data/rime-data-0.32.ebuild
+++ b/app-i18n/rime-data/rime-data-0.32.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/app-i18n/rime-data/rime-data-0.32.ebuild,v 1.1 2014/01/11 01:10:00 dlan Exp $
 
 EAPI=7
 

--- a/app-i18n/rime-data/rime-data-0.32.ebuild
+++ b/app-i18n/rime-data/rime-data-0.32.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/app-i18n/rime-data/rime-data-0.32.ebuild,v 1.1 2014/01/11 01:10:00 dlan Exp $
 

--- a/app-i18n/rime-data/rime-data-9999.ebuild
+++ b/app-i18n/rime-data/rime-data-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/rime-data/rime-data-9999.ebuild
+++ b/app-i18n/rime-data/rime-data-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/scim-array/scim-array-1.0.0.ebuild
+++ b/app-i18n/scim-array/scim-array-1.0.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-i18n/scim-array/scim-array-1.0.0.ebuild
+++ b/app-i18n/scim-array/scim-array-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/scim-array/scim-array-1.0.1.ebuild
+++ b/app-i18n/scim-array/scim-array-1.0.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-i18n/scim-array/scim-array-1.0.1.ebuild
+++ b/app-i18n/scim-array/scim-array-1.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/scim-chewing/scim-chewing-0.5.1.ebuild
+++ b/app-i18n/scim-chewing/scim-chewing-0.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/scim-chewing/scim-chewing-0.5.1.ebuild
+++ b/app-i18n/scim-chewing/scim-chewing-0.5.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 inherit eutils

--- a/app-i18n/scim-chrasis/scim-chrasis-9999.0.0.1.ebuild
+++ b/app-i18n/scim-chrasis/scim-chrasis-9999.0.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/scim-chrasis/scim-chrasis-9999.0.0.1.ebuild
+++ b/app-i18n/scim-chrasis/scim-chrasis-9999.0.0.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/sogoupinyin/sogoupinyin-2.2.0.0102.ebuild
+++ b/app-i18n/sogoupinyin/sogoupinyin-2.2.0.0102.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/sogoupinyin/sogoupinyin-2.2.0.0102.ebuild
+++ b/app-i18n/sogoupinyin/sogoupinyin-2.2.0.0102.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-i18n/ucimf-chewing/ucimf-chewing-0.3.ebuild
+++ b/app-i18n/ucimf-chewing/ucimf-chewing-0.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="The Chewing IMF module for UCIMF"
 HOMEPAGE="http://ucimf.googlecode.com"

--- a/app-i18n/ucimf-chewing/ucimf-chewing-0.3.ebuild
+++ b/app-i18n/ucimf-chewing/ucimf-chewing-0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.4.ebuild
+++ b/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.4.ebuild
+++ b/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="The SunPinyin IMF module for UCIMF"
 HOMEPAGE="http://ucimf.googlecode.com"

--- a/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.5.ebuild
+++ b/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.5.ebuild
+++ b/app-i18n/ucimf-sunpinyin/ucimf-sunpinyin-0.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="The SunPinyin IMF module for UCIMF"
 HOMEPAGE="http://ucimf.googlecode.com"

--- a/app-i18n/zh-autoconvert/zh-autoconvert-0.3.16-r3.ebuild
+++ b/app-i18n/zh-autoconvert/zh-autoconvert-0.3.16-r3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-i18n/zh-autoconvert/zh-autoconvert-0.3.16-r3.ebuild
+++ b/app-i18n/zh-autoconvert/zh-autoconvert-0.3.16-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-misc/bcompare/bcompare-4.2.2.22384.ebuild
+++ b/app-misc/bcompare/bcompare-4.2.2.22384.ebuild
@@ -1,6 +1,5 @@
 # Copyright 2016-2021 Chun-Yu Lee (Mat) <matlinuxer2@gmail.com>
 # Distributed under the terms of the MIT License
-# $Header: $
 
 EAPI=7
 

--- a/app-misc/bcompare/bcompare-4.2.2.22384.ebuild
+++ b/app-misc/bcompare/bcompare-4.2.2.22384.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2016 Chun-Yu Lee (Mat) <matlinuxer2@gmail.com>
+# Copyright 2016-2021 Chun-Yu Lee (Mat) <matlinuxer2@gmail.com>
 # Distributed under the terms of the MIT License
 # $Header: $
 

--- a/app-misc/freefilesync/freefilesync-5.6.ebuild
+++ b/app-misc/freefilesync/freefilesync-5.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-misc/freefilesync/freefilesync-5.6.ebuild
+++ b/app-misc/freefilesync/freefilesync-5.6.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-misc/gpick/gpick-0.2.5.ebuild
+++ b/app-misc/gpick/gpick-0.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-misc/gpick/gpick-0.2.5.ebuild
+++ b/app-misc/gpick/gpick-0.2.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/app-misc/nixnote/nixnote-2.1.6.ebuild
+++ b/app-misc/nixnote/nixnote-2.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-misc/screen/screen-4.2.1-r2.ebuild
+++ b/app-misc/screen/screen-4.2.1-r2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/app-misc/screen/screen-4.2.1-r2.ebuild,v 1.2 2014/08/23 09:14:27 jer Exp $
 
 EAPI=5
 

--- a/app-misc/screen/screen-4.2.1-r2.ebuild
+++ b/app-misc/screen/screen-4.2.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/app-misc/screen/screen-4.2.1-r2.ebuild,v 1.2 2014/08/23 09:14:27 jer Exp $
 

--- a/app-misc/wink/wink-1.5.ebuild
+++ b/app-misc/wink/wink-1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-misc/wink/wink-1.5.ebuild
+++ b/app-misc/wink/wink-1.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-mobilephone/scrcpy/scrcpy-1.14.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-1.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-office/wps-office/wps-office-11.1.0.9719.ebuild
+++ b/app-office/wps-office/wps-office-11.1.0.9719.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-pda/ipadcharge/ipadcharge-9999.ebuild
+++ b/app-pda/ipadcharge/ipadcharge-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-pda/ipadcharge/ipadcharge-9999.ebuild
+++ b/app-pda/ipadcharge/ipadcharge-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-portage/findcruft/findcruft-1.0.4-r1.ebuild
+++ b/app-portage/findcruft/findcruft-1.0.4-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-portage/findcruft/findcruft-1.0.4-r1.ebuild
+++ b/app-portage/findcruft/findcruft-1.0.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-portage/portage-cdb/portage-cdb-0.2.1.ebuild
+++ b/app-portage/portage-cdb/portage-cdb-0.2.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="increase portage's speed after syncing, and for calculating dependencies. This method uses a database, rather than a bunch of flat files to store its metadata."
 HOMEPAGE="http://gentoo-wiki.com/TIP_speed_up_portage_with_cdb"

--- a/app-portage/portage-cdb/portage-cdb-0.2.1.ebuild
+++ b/app-portage/portage-cdb/portage-cdb-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/asciiio/asciiio-1.ebuild
+++ b/app-text/asciiio/asciiio-1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/asciiio/asciiio-1.ebuild
+++ b/app-text/asciiio/asciiio-1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-text/groff-utf8/groff-utf8-0-r1.ebuild
+++ b/app-text/groff-utf8/groff-utf8-0-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="GNU groff wrapper allowing UTF-8 input"
 HOMEPAGE="http://www.haible.de/bruno/packages-groff-utf8.html"

--- a/app-text/groff-utf8/groff-utf8-0-r1.ebuild
+++ b/app-text/groff-utf8/groff-utf8-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/openyoudao/openyoudao-9999.ebuild
+++ b/app-text/openyoudao/openyoudao-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/openyoudao/openyoudao-9999.ebuild
+++ b/app-text/openyoudao/openyoudao-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-text/reciteword-books/reciteword-books-0.8.3.ebuild
+++ b/app-text/reciteword-books/reciteword-books-0.8.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-text/reciteword-books/reciteword-books-0.8.3.ebuild
+++ b/app-text/reciteword-books/reciteword-books-0.8.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/reciteword-books/reciteword-books-0.8.4.ebuild
+++ b/app-text/reciteword-books/reciteword-books-0.8.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-text/reciteword-books/reciteword-books-0.8.4.ebuild
+++ b/app-text/reciteword-books/reciteword-books-0.8.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/reciteword-dicts/reciteword-dicts-0.8.2.ebuild
+++ b/app-text/reciteword-dicts/reciteword-dicts-0.8.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-text/reciteword-dicts/reciteword-dicts-0.8.2.ebuild
+++ b/app-text/reciteword-dicts/reciteword-dicts-0.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/reciteword-skins-rw/reciteword-skins-rw-0.8.2.ebuild
+++ b/app-text/reciteword-skins-rw/reciteword-skins-rw-0.8.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-text/reciteword-skins-rw/reciteword-skins-rw-0.8.2.ebuild
+++ b/app-text/reciteword-skins-rw/reciteword-skins-rw-0.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/reciteword-skins-rw_en/reciteword-skins-rw_en-0.8.2.ebuild
+++ b/app-text/reciteword-skins-rw_en/reciteword-skins-rw_en-0.8.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-text/reciteword-skins-rw_en/reciteword-skins-rw_en-0.8.2.ebuild
+++ b/app-text/reciteword-skins-rw_en/reciteword-skins-rw_en-0.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/reciteword/reciteword-0.8.5.ebuild
+++ b/app-text/reciteword/reciteword-0.8.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/reciteword/reciteword-0.8.5.ebuild
+++ b/app-text/reciteword/reciteword-0.8.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit eutils

--- a/app-text/srecite/srecite-0.6.2.ebuild
+++ b/app-text/srecite/srecite-0.6.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/app-text/srecite/srecite-0.6.2.ebuild
+++ b/app-text/srecite/srecite-0.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/wiznote/wiznote-2.1.14.ebuild
+++ b/app-text/wiznote/wiznote-2.1.14.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
-# $Header: $
 
 EAPI=7
 

--- a/app-text/wiznote/wiznote-2.1.14.ebuild
+++ b/app-text/wiznote/wiznote-2.1.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 

--- a/app-text/wiznote/wiznote-2.4.0.ebuild
+++ b/app-text/wiznote/wiznote-2.4.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
-# $Header: $
 
 EAPI=7
 

--- a/app-text/wiznote/wiznote-2.4.0.ebuild
+++ b/app-text/wiznote/wiznote-2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 

--- a/app-text/wiznote/wiznote-9999.ebuild
+++ b/app-text/wiznote/wiznote-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
-# $Header: $
 
 EAPI=7
 

--- a/app-text/wiznote/wiznote-9999.ebuild
+++ b/app-text/wiznote/wiznote-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 

--- a/app-text/xdvipdfmx/xdvipdfmx-9999.ebuild
+++ b/app-text/xdvipdfmx/xdvipdfmx-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-text/xdvipdfmx/xdvipdfmx-9999.ebuild
+++ b/app-text/xdvipdfmx/xdvipdfmx-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-text/ydcv-rs/ydcv-rs-0.4.7.ebuild
+++ b/app-text/ydcv-rs/ydcv-rs-0.4.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License-2
 
 EAPI=7

--- a/app-vim/clang_complete/clang_complete-1.8.ebuild
+++ b/app-vim/clang_complete/clang_complete-1.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-vim/clang_complete/clang_complete-1.8.ebuild
+++ b/app-vim/clang_complete/clang_complete-1.8.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-vim/easymotion/easymotion-1.3.ebuild
+++ b/app-vim/easymotion/easymotion-1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-vim/easymotion/easymotion-1.3.ebuild
+++ b/app-vim/easymotion/easymotion-1.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/app-vim/echofunc/echofunc-1.18.ebuild
+++ b/app-vim/echofunc/echofunc-1.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-vim/echofunc/echofunc-1.18.ebuild
+++ b/app-vim/echofunc/echofunc-1.18.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit vim-plugin
 

--- a/app-vim/icomplete/icomplete-0.4.ebuild
+++ b/app-vim/icomplete/icomplete-0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-vim/icomplete/icomplete-0.4.ebuild
+++ b/app-vim/icomplete/icomplete-0.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit vim-plugin
 

--- a/app-vim/powerline/powerline-9999.ebuild
+++ b/app-vim/powerline/powerline-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/app-vim/powerline/powerline-9999.ebuild
+++ b/app-vim/powerline/powerline-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-cpp/ETL/ETL-0.04.22.ebuild
+++ b/dev-cpp/ETL/ETL-0.04.22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-cpp/cppformat/cppformat-1.1.0.ebuild
+++ b/dev-cpp/cppformat/cppformat-1.1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-cpp/cppformat/cppformat-1.1.0.ebuild
+++ b/dev-cpp/cppformat/cppformat-1.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-db/dbdesigner/dbdesigner-4.0.5.4.ebuild
+++ b/dev-db/dbdesigner/dbdesigner-4.0.5.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/dev-db/dbdesigner/dbdesigner-4.0.5.4.ebuild
+++ b/dev-db/dbdesigner/dbdesigner-4.0.5.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-lang/scala-bin/scala-bin-2.12.8.ebuild
+++ b/dev-lang/scala-bin/scala-bin-2.12.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-lang/scala-bin/scala-bin-2.13.0.ebuild
+++ b/dev-lang/scala-bin/scala-bin-2.13.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-lang/swig/swig-4.0.0.ebuild
+++ b/dev-lang/swig/swig-4.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-libs/granite/granite-5.2.1.ebuild
+++ b/dev-libs/granite/granite-5.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-libs/libchrasis/libchrasis-9999.0.1.1.ebuild
+++ b/dev-libs/libchrasis/libchrasis-9999.0.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-libs/libchrasis/libchrasis-9999.0.1.1.ebuild
+++ b/dev-libs/libchrasis/libchrasis-9999.0.1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-libs/libdwarf/libdwarf-20140208.ebuild
+++ b/dev-libs/libdwarf/libdwarf-20140208.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-libs/libdwarf/libdwarf-20140208.ebuild
+++ b/dev-libs/libdwarf/libdwarf-20140208.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-libs/libtsm/libtsm-3.ebuild
+++ b/dev-libs/libtsm/libtsm-3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-libs/libtsm/libtsm-3.ebuild
+++ b/dev-libs/libtsm/libtsm-3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-libs/lunar-date/lunar-date-2.4.2.ebuild
+++ b/dev-libs/lunar-date/lunar-date-2.4.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 EAPI=6
 
 inherit autotools

--- a/dev-libs/lunar-date/lunar-date-2.4.2.ebuild
+++ b/dev-libs/lunar-date/lunar-date-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 EAPI=6

--- a/dev-libs/tdlib/tdlib-1.5.0.ebuild
+++ b/dev-libs/tdlib/tdlib-1.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-libs/tdlib/tdlib-1.6.0.ebuild
+++ b/dev-libs/tdlib/tdlib-1.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-libs/tdlib/tdlib-9999.ebuild
+++ b/dev-libs/tdlib/tdlib-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-php/pecl-solr/pecl-solr-2.4.0.ebuild
+++ b/dev-php/pecl-solr/pecl-solr-2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-python/fuo-kuwo/fuo-kuwo-0.1.2.ebuild
+++ b/dev-python/fuo-kuwo/fuo-kuwo-0.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/fuo-local/fuo-local-0.2.1.ebuild
+++ b/dev-python/fuo-local/fuo-local-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/fuo-netease/fuo-netease-0.5.ebuild
+++ b/dev-python/fuo-netease/fuo-netease-0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/fuo-qqmusic/fuo-qqmusic-0.3.ebuild
+++ b/dev-python/fuo-qqmusic/fuo-qqmusic-0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/fuo-xiami/fuo-xiami-0.2.4.ebuild
+++ b/dev-python/fuo-xiami/fuo-xiami-0.2.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/janus/janus-0.4.0.ebuild
+++ b/dev-python/janus/janus-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/pydantic/pydantic-1.7.3.ebuild
+++ b/dev-python/pydantic/pydantic-1.7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/qasync/qasync-0.9.4.ebuild
+++ b/dev-python/qasync/qasync-0.9.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-python/tomlkit/tomlkit-0.7.0.ebuild
+++ b/dev-python/tomlkit/tomlkit-0.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.13.2.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.13.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.14.1.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.14.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-util/arch-install-scripts/arch-install-scripts-20.ebuild
+++ b/dev-util/arch-install-scripts/arch-install-scripts-20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-util/bom-utils/bom-utils-1.0.ebuild
+++ b/dev-util/bom-utils/bom-utils-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-util/bom-utils/bom-utils-1.0.ebuild
+++ b/dev-util/bom-utils/bom-utils-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-util/ccls/ccls-0.20190314.1.ebuild
+++ b/dev-util/ccls/ccls-0.20190314.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 Gentoo Foundation
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2 or later
 
 EAPI=6

--- a/dev-util/elfembed/elfembed-0.3.ebuild
+++ b/dev-util/elfembed/elfembed-0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-util/elfembed/elfembed-0.3.ebuild
+++ b/dev-util/elfembed/elfembed-0.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-util/fernflower/fernflower-1.ebuild
+++ b/dev-util/fernflower/fernflower-1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-util/fernflower/fernflower-1.ebuild
+++ b/dev-util/fernflower/fernflower-1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 

--- a/dev-util/global/global-6.3.4.ebuild
+++ b/dev-util/global/global-6.3.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header:
 
 EAPI=7
 

--- a/dev-util/global/global-6.3.4.ebuild
+++ b/dev-util/global/global-6.3.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header:
 

--- a/dev-util/jd-gui/jd-gui-1.4.0.ebuild
+++ b/dev-util/jd-gui/jd-gui-1.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-util/jetbrains-toolbox/jetbrains-toolbox-1.20.7939.ebuild
+++ b/dev-util/jetbrains-toolbox/jetbrains-toolbox-1.20.7939.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Copyright 2019 Rabenda

--- a/dev-util/rinse/rinse-1.7.ebuild
+++ b/dev-util/rinse/rinse-1.7.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="RPM based distributions bootstrap scripts"
 HOMEPAGE="http://www.xen-tools.org/software/rinse"

--- a/dev-util/rinse/rinse-1.7.ebuild
+++ b/dev-util/rinse/rinse-1.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-util/rinse/rinse-9999.ebuild
+++ b/dev-util/rinse/rinse-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-util/rinse/rinse-9999.ebuild
+++ b/dev-util/rinse/rinse-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/dev-util/rust-analyzer/rust-analyzer-20200928.ebuild
+++ b/dev-util/rust-analyzer/rust-analyzer-20200928.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/dev-util/yabasic/yabasic-2.9.15.ebuild
+++ b/dev-util/yabasic/yabasic-2.9.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/dev-util/yabasic/yabasic-2.9.15.ebuild
+++ b/dev-util/yabasic/yabasic-2.9.15.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/games-board/othello/othello-0.2.0.ebuild
+++ b/games-board/othello/othello-0.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/games-board/othello/othello-0.2.0.ebuild
+++ b/games-board/othello/othello-0.2.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit games
 

--- a/games-board/othello/othello-0.2.1.ebuild
+++ b/games-board/othello/othello-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/games-board/othello/othello-0.2.1.ebuild
+++ b/games-board/othello/othello-0.2.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit games
 

--- a/games-misc/fortune-mod-zh/fortune-mod-zh-1.2.2.ebuild
+++ b/games-misc/fortune-mod-zh/fortune-mod-zh-1.2.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Chinese fortune shell script"
 HOMEPAGE="http://code.google.com/p/chinese-fortune"

--- a/games-misc/fortune-mod-zh/fortune-mod-zh-1.2.2.ebuild
+++ b/games-misc/fortune-mod-zh/fortune-mod-zh-1.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/kde-misc/imageshack-upload/imageshack-upload-0.5.ebuild
+++ b/kde-misc/imageshack-upload/imageshack-upload-0.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="A service menu tor upload images on Imageshack."
 HOMEPAGE="http://kde-apps.org/content/show.php?content=51247"

--- a/kde-misc/imageshack-upload/imageshack-upload-0.5.ebuild
+++ b/kde-misc/imageshack-upload/imageshack-upload-0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-1.8-r1.ebuild
+++ b/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-1.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-9999.ebuild
+++ b/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-fonts/cwtex-q-fonts/cwtex-q-fonts-0.2.ebuild
+++ b/media-fonts/cwtex-q-fonts/cwtex-q-fonts-0.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit font

--- a/media-fonts/cwtex-q-fonts/cwtex-q-fonts-0.2.ebuild
+++ b/media-fonts/cwtex-q-fonts/cwtex-q-fonts-0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-fonts/ntufonts/ntufonts-20030521.ebuild
+++ b/media-fonts/ntufonts/ntufonts-20030521.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-fonts/ntufonts/ntufonts-20030521.ebuild
+++ b/media-fonts/ntufonts/ntufonts-20030521.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI="7"
 

--- a/media-fonts/sinicafonts/sinicafonts-20030521.ebuild
+++ b/media-fonts/sinicafonts/sinicafonts-20030521.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-fonts/sinicafonts/sinicafonts-20030521.ebuild
+++ b/media-fonts/sinicafonts/sinicafonts-20030521.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI="7"
 

--- a/media-fonts/ttf-wps-fonts/ttf-wps-fonts-1.0.ebuild
+++ b/media-fonts/ttf-wps-fonts/ttf-wps-fonts-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-fonts/wangfonts/wangfonts-1.3.0.ebuild
+++ b/media-fonts/wangfonts/wangfonts-1.3.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI="7"
 inherit font

--- a/media-fonts/wangfonts/wangfonts-1.3.0.ebuild
+++ b/media-fonts/wangfonts/wangfonts-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-fonts/wps-office-fonts/wps-office-fonts-1.0.ebuild
+++ b/media-fonts/wps-office-fonts/wps-office-fonts-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-gfx/blur-effect/blur-effect-1.1.3.ebuild
+++ b/media-gfx/blur-effect/blur-effect-1.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/media-gfx/byzanz/byzanz-0.3.0.9999.ebuild
+++ b/media-gfx/byzanz/byzanz-0.3.0.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/media-gfx/sane-backends/sane-backends-9999.ebuild
+++ b/media-gfx/sane-backends/sane-backends-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-gfx/sane-backends/sane-backends-9999.ebuild
+++ b/media-gfx/sane-backends/sane-backends-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/media-gfx/scangearmp/scangearmp-1.60.ebuild
+++ b/media-gfx/scangearmp/scangearmp-1.60.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-gfx/scangearmp/scangearmp-1.60.ebuild
+++ b/media-gfx/scangearmp/scangearmp-1.60.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 # Changelog since last bugzilla upload 
 # 

--- a/media-gfx/xrectsel/xrectsel-0.3.1.ebuild
+++ b/media-gfx/xrectsel/xrectsel-0.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-gfx/xrectsel/xrectsel-0.3.1.ebuild
+++ b/media-gfx/xrectsel/xrectsel-0.3.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.2.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.2.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P="${P}"
 S="${WORKDIR}/${MY_P}"

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.4.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.4.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P="${P}"
 S="${WORKDIR}/${MY_P}"

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.5.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.5.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.7.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P="${P}"
 S="${WORKDIR}/${MY_P}"

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.8.0.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-libs/ksquirrel-libs/ksquirrel-libs-0.8.0.ebuild
+++ b/media-libs/ksquirrel-libs/ksquirrel-libs-0.8.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 MY_P="${P}"
 S="${WORKDIR}/${MY_P}"

--- a/media-libs/libspiro/libspiro-0.3.20150131.ebuild
+++ b/media-libs/libspiro/libspiro-0.3.20150131.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/media-libs/libspiro/libspiro-0.3.20150131.ebuild
+++ b/media-libs/libspiro/libspiro-0.3.20150131.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-libs/libuninameslist/libuninameslist-20140731.ebuild
+++ b/media-libs/libuninameslist/libuninameslist-20140731.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/media-libs/libuninameslist/libuninameslist-20091231.ebuild,v 1.10 2014/06/10 00:56:14 vapier Exp $
 

--- a/media-libs/libuninameslist/libuninameslist-20140731.ebuild
+++ b/media-libs/libuninameslist/libuninameslist-20140731.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/media-libs/libuninameslist/libuninameslist-20091231.ebuild,v 1.10 2014/06/10 00:56:14 vapier Exp $
 
 EAPI=7
 

--- a/media-libs/libuninameslist/libuninameslist-20190701.ebuild
+++ b/media-libs/libuninameslist/libuninameslist-20190701.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-plugins/audacious-mac/audacious-mac-0.2.0.ebuild
+++ b/media-plugins/audacious-mac/audacious-mac-0.2.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Monkey's Audio Codec plugin for audacious"
 HOMEPAGE="http://www.netswarm.net/"

--- a/media-plugins/audacious-mac/audacious-mac-0.2.0.ebuild
+++ b/media-plugins/audacious-mac/audacious-mac-0.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-plugins/audacious-mac/audacious-mac-0.3.10.ebuild
+++ b/media-plugins/audacious-mac/audacious-mac-0.3.10.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Monkey's Audio Codec plugin for audacious"
 HOMEPAGE="http://www.netswarm.net/"

--- a/media-plugins/audacious-mac/audacious-mac-0.3.10.ebuild
+++ b/media-plugins/audacious-mac/audacious-mac-0.3.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
+++ b/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Technologies, Inc.
+# Copyright 1999-2021 Gentoo Technologies, Inc.
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
+++ b/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Technologies, Inc.
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils flag-o-matic
 

--- a/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
+++ b/media-plugins/gimp-gap/gimp-gap-2.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Technologies, Inc.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 inherit eutils flag-o-matic

--- a/media-plugins/gst-plugins-meta/gst-plugins-meta-0.10-r8.ebuild
+++ b/media-plugins/gst-plugins-meta/gst-plugins-meta-0.10-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/media-plugins/gst-plugins-meta/gst-plugins-meta-0.10-r8.ebuild,v 1.18 2013/04/01 18:25:12 ago Exp $
 

--- a/media-plugins/gst-plugins-meta/gst-plugins-meta-0.10-r8.ebuild
+++ b/media-plugins/gst-plugins-meta/gst-plugins-meta-0.10-r8.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/media-plugins/gst-plugins-meta/gst-plugins-meta-0.10-r8.ebuild,v 1.18 2013/04/01 18:25:12 ago Exp $
 
 EAPI=7
 

--- a/media-plugins/osdlyrics/osdlyrics-20200403.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-20200403.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-plugins/osdlyrics/osdlyrics-9999.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-sound/audio-convert-mod/audio-convert-mod-3.45.2.ebuild
+++ b/media-sound/audio-convert-mod/audio-convert-mod-3.45.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-sound/audio-convert-mod/audio-convert-mod-3.45.2.ebuild
+++ b/media-sound/audio-convert-mod/audio-convert-mod-3.45.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="A simple audio file converter supporting many formats"
 HOMEPAGE="http://www.diffingo.com"

--- a/media-sound/cue2tracks/cue2tracks-0.2.16.ebuild
+++ b/media-sound/cue2tracks/cue2tracks-0.2.16.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/media-sound/cue2tracks/cue2tracks-0.2.16.ebuild
+++ b/media-sound/cue2tracks/cue2tracks-0.2.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2008 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-sound/feeluown/feeluown-3.7.3.ebuild
+++ b/media-sound/feeluown/feeluown-3.7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/media-sound/linnya/linnya-2.2.0.ebuild
+++ b/media-sound/linnya/linnya-2.2.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit eutils vcs-snapshot

--- a/media-sound/linnya/linnya-2.2.0.ebuild
+++ b/media-sound/linnya/linnya-2.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-video/avplayer/avplayer-9999.ebuild
+++ b/media-video/avplayer/avplayer-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 inherit cmake-utils git-r3

--- a/media-video/avplayer/avplayer-9999.ebuild
+++ b/media-video/avplayer/avplayer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-video/lightworks/lightworks-2020.1-r3.ebuild
+++ b/media-video/lightworks/lightworks-2020.1-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/media-video/lightworks/lightworks-2021.1-r1.ebuild
+++ b/media-video/lightworks/lightworks-2021.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/media-video/simplescreenrecorder/simplescreenrecorder-0.3.3-r1.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-0.3.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-video/simplescreenrecorder/simplescreenrecorder-0.3.3-r1.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-0.3.3-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/media-video/tenvideo/tenvideo-1.0.10.ebuild
+++ b/media-video/tenvideo/tenvideo-1.0.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-dialup/mentohust/mentohust-9999.ebuild
+++ b/net-dialup/mentohust/mentohust-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-dialup/mentohust/mentohust-9999.ebuild
+++ b/net-dialup/mentohust/mentohust-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-dns/chinadns/chinadns-1.3.2.ebuild
+++ b/net-dns/chinadns/chinadns-1.3.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-dns/chinadns/chinadns-1.3.2.ebuild
+++ b/net-dns/chinadns/chinadns-1.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-dns/dnscrypt-proxy/dnscrypt-proxy-9999.ebuild
+++ b/net-dns/dnscrypt-proxy/dnscrypt-proxy-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-dns/dnscrypt-proxy/dnscrypt-proxy-9999.ebuild
+++ b/net-dns/dnscrypt-proxy/dnscrypt-proxy-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-dns/phddns/phddns-2.0.6.32828.ebuild
+++ b/net-dns/phddns/phddns-2.0.6.32828.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-im/aliwangwang/aliwangwang-1.00-r1.ebuild
+++ b/net-im/aliwangwang/aliwangwang-1.00-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-im/aliwangwang/aliwangwang-1.00-r1.ebuild
+++ b/net-im/aliwangwang/aliwangwang-1.00-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-im/avim/avim-0.1.ebuild
+++ b/net-im/avim/avim-0.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/net-im/avim/avim-0.1.ebuild
+++ b/net-im/avim/avim-0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-im/freetalk/freetalk-4.1.ebuild
+++ b/net-im/freetalk/freetalk-4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-im/freetalk/freetalk-4.1.ebuild
+++ b/net-im/freetalk/freetalk-4.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/net-im/telegram-purple/telegram-purple-1.3.0.ebuild
+++ b/net-im/telegram-purple/telegram-purple-1.3.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/net-im/telegram-purple/telegram-purple-1.3.0.ebuild
+++ b/net-im/telegram-purple/telegram-purple-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-im/telegram-purple/telegram-purple-9999.ebuild
+++ b/net-im/telegram-purple/telegram-purple-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/net-im/telegram-purple/telegram-purple-9999.ebuild
+++ b/net-im/telegram-purple/telegram-purple-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-im/tencent-qq/tencent-qq-2.0.0_beta2-r1.ebuild
+++ b/net-im/tencent-qq/tencent-qq-2.0.0_beta2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-im/wechat-uos/wechat-uos-2.0.0.ebuild
+++ b/net-im/wechat-uos/wechat-uos-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-libs/jzmq/jzmq-9999.ebuild
+++ b/net-libs/jzmq/jzmq-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="jzmq"
 HOMEPAGE="http://www.zeromq.org/bindings:java"

--- a/net-libs/jzmq/jzmq-9999.ebuild
+++ b/net-libs/jzmq/jzmq-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/avsocks/avsocks-9999.ebuild
+++ b/net-misc/avsocks/avsocks-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/avsocks/avsocks-9999.ebuild
+++ b/net-misc/avsocks/avsocks-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-misc/baidunetdisk/baidunetdisk-3.0.1.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-3.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-misc/baidunetdisk/baidunetdisk-3.4.1.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-3.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-misc/baidunetdisk/baidunetdisk-3.5.0.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-3.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-misc/baidupcs-go/baidupcs-go-3.6.2.ebuild
+++ b/net-misc/baidupcs-go/baidupcs-go-3.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-misc/baidupcs-go/baidupcs-go-9999.ebuild
+++ b/net-misc/baidupcs-go/baidupcs-go-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-misc/libipmsg/libipmsg-0.1.6.ebuild
+++ b/net-misc/libipmsg/libipmsg-0.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/libipmsg/libipmsg-0.1.6.ebuild
+++ b/net-misc/libipmsg/libipmsg-0.1.6.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils 
 

--- a/net-misc/libipmsg/libipmsg-0.1.7.ebuild
+++ b/net-misc/libipmsg/libipmsg-0.1.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/libipmsg/libipmsg-0.1.7.ebuild
+++ b/net-misc/libipmsg/libipmsg-0.1.7.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils 
 

--- a/net-misc/logjam/logjam-4.5.3.ebuild
+++ b/net-misc/logjam/logjam-4.5.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/logjam/logjam-4.5.3.ebuild
+++ b/net-misc/logjam/logjam-4.5.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 IUSE="gtk gtkhtml spell sqlite svg xmms"
 

--- a/net-misc/networkmanager-l2tp/networkmanager-l2tp-9999.ebuild
+++ b/net-misc/networkmanager-l2tp/networkmanager-l2tp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/networkmanager-l2tp/networkmanager-l2tp-9999.ebuild
+++ b/net-misc/networkmanager-l2tp/networkmanager-l2tp-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-misc/omnitty/omnitty-0.3.0.ebuild
+++ b/net-misc/omnitty/omnitty-0.3.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/net-misc/omnitty/omnitty-0.3.0.ebuild
+++ b/net-misc/omnitty/omnitty-0.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-misc/prips/prips-1.0.0.ebuild
+++ b/net-misc/prips/prips-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/net-misc/tiebasprit/tiebasprit-0.3.1.ebuild
+++ b/net-misc/tiebasprit/tiebasprit-0.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/tiebasprit/tiebasprit-0.3.1.ebuild
+++ b/net-misc/tiebasprit/tiebasprit-0.3.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-misc/xmuruijie/xmuruijie-1.4.3.ebuild
+++ b/net-misc/xmuruijie/xmuruijie-1.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/xmuruijie/xmuruijie-1.4.3.ebuild
+++ b/net-misc/xmuruijie/xmuruijie-1.4.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-misc/you-get/you-get-9999.ebuild
+++ b/net-misc/you-get/you-get-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-misc/you-get/you-get-9999.ebuild
+++ b/net-misc/you-get/you-get-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-p2p/amule-dlp-antileech/amule-dlp-antileech-9999.ebuild
+++ b/net-p2p/amule-dlp-antileech/amule-dlp-antileech-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-p2p/amule-dlp-antileech/amule-dlp-antileech-9999.ebuild
+++ b/net-p2p/amule-dlp-antileech/amule-dlp-antileech-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-p2p/amule-dlp/amule-dlp-9999.ebuild
+++ b/net-p2p/amule-dlp/amule-dlp-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-p2p/amule-dlp/amule-dlp-9999.ebuild
+++ b/net-p2p/amule-dlp/amule-dlp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-p2p/n2n/n2n-2.6.ebuild
+++ b/net-p2p/n2n/n2n-2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-print/cndrvcups-common-lb/cndrvcups-common-lb-3.40-r1.ebuild
+++ b/net-print/cndrvcups-common-lb/cndrvcups-common-lb-3.40-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/net-print/cndrvcups-lb/cndrvcups-lb-3.40-r1.ebuild
+++ b/net-print/cndrvcups-lb/cndrvcups-lb-3.40-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/net-print/cups-tsc/cups-tsc-0.1.26.ebuild
+++ b/net-print/cups-tsc/cups-tsc-0.1.26.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-print/cups-tsc/cups-tsc-0.1.26.ebuild
+++ b/net-print/cups-tsc/cups-tsc-0.1.26.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit toolchain-funcs multilib
 

--- a/net-print/hplip-plugin/hplip-plugin-3.14.1.ebuild
+++ b/net-print/hplip-plugin/hplip-plugin-3.14.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-print/hplip-plugin/hplip-plugin-3.14.1.ebuild
+++ b/net-print/hplip-plugin/hplip-plugin-3.14.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-proxy/lantern-bin/lantern-bin-3.0.4.ebuild
+++ b/net-proxy/lantern-bin/lantern-bin-3.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/libQtShadowsocks/libQtShadowsocks-2.1.0.ebuild
+++ b/net-proxy/libQtShadowsocks/libQtShadowsocks-2.1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 inherit cmake-utils

--- a/net-proxy/libQtShadowsocks/libQtShadowsocks-2.1.0.ebuild
+++ b/net-proxy/libQtShadowsocks/libQtShadowsocks-2.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-proxy/make-proxy/make-proxy-2.0.0.ebuild
+++ b/net-proxy/make-proxy/make-proxy-2.0.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-proxy/make-proxy/make-proxy-2.0.0.ebuild
+++ b/net-proxy/make-proxy/make-proxy-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-proxy/qv2ray/qv2ray-2.6.3-r1.ebuild
+++ b/net-proxy/qv2ray/qv2ray-2.6.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qv2ray/qv2ray-99999.ebuild
+++ b/net-proxy/qv2ray/qv2ray-99999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-command/qvplugin-command-2.0.0.ebuild
+++ b/net-proxy/qvplugin-command/qvplugin-command-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-command/qvplugin-command-99999.ebuild
+++ b/net-proxy/qvplugin-command/qvplugin-command-99999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-ss/qvplugin-ss-1.2.ebuild
+++ b/net-proxy/qvplugin-ss/qvplugin-ss-1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-ssr/qvplugin-ssr-2.0.3.ebuild
+++ b/net-proxy/qvplugin-ssr/qvplugin-ssr-2.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-ssr/qvplugin-ssr-9999.ebuild
+++ b/net-proxy/qvplugin-ssr/qvplugin-ssr-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-trojan/qvplugin-trojan-2.0.0.ebuild
+++ b/net-proxy/qvplugin-trojan/qvplugin-trojan-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/qvplugin-trojan/qvplugin-trojan-99999.ebuild
+++ b/net-proxy/qvplugin-trojan/qvplugin-trojan-99999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/shadowsocks-qt5/shadowsocks-qt5-3.0.1.ebuild
+++ b/net-proxy/shadowsocks-qt5/shadowsocks-qt5-3.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-proxy/shadowsocks-qt5/shadowsocks-qt5-3.0.1.ebuild
+++ b/net-proxy/shadowsocks-qt5/shadowsocks-qt5-3.0.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-proxy/shadowsocks/shadowsocks-9999.ebuild
+++ b/net-proxy/shadowsocks/shadowsocks-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-proxy/shadowsocks/shadowsocks-9999.ebuild
+++ b/net-proxy/shadowsocks/shadowsocks-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-proxy/shadowvpn/shadowvpn-9999.ebuild
+++ b/net-proxy/shadowvpn/shadowvpn-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-proxy/shadowvpn/shadowvpn-9999.ebuild
+++ b/net-proxy/shadowvpn/shadowvpn-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-proxy/simple-obfs/simple-obfs-0.0.5.ebuild
+++ b/net-proxy/simple-obfs/simple-obfs-0.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/net-proxy/smartproxy/smartproxy-0.9.4.ebuild
+++ b/net-proxy/smartproxy/smartproxy-0.9.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/net-proxy/smartproxy/smartproxy-0.9.4.ebuild
+++ b/net-proxy/smartproxy/smartproxy-0.9.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/net-proxy/v2-ui-bin/v2-ui-bin-5.1.2.ebuild
+++ b/net-proxy/v2-ui-bin/v2-ui-bin-5.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/v2-ui-bin/v2-ui-bin-5.2.0.ebuild
+++ b/net-proxy/v2-ui-bin/v2-ui-bin-5.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/v2ray-bin/v2ray-bin-4.27.5.ebuild
+++ b/net-proxy/v2ray-bin/v2ray-bin-4.27.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/net-proxy/v2ray/v2ray-4.33.0.ebuild
+++ b/net-proxy/v2ray/v2ray-4.33.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/sci-libs/libticables2/libticables2-9999.ebuild
+++ b/sci-libs/libticables2/libticables2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/sci-libs/libticables2/libticables2-1.3.4.ebuild,v 1.1 2013/07/09 16:42:43 bicatali Exp $
 

--- a/sci-libs/libticables2/libticables2-9999.ebuild
+++ b/sci-libs/libticables2/libticables2-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/sci-libs/libticables2/libticables2-1.3.4.ebuild,v 1.1 2013/07/09 16:42:43 bicatali Exp $
 
 EAPI=7
 

--- a/sci-libs/libticalcs2/libticalcs2-9999.ebuild
+++ b/sci-libs/libticalcs2/libticalcs2-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/sci-libs/libticalcs2/libticalcs2-1.1.8.ebuild,v 1.1 2013/07/09 16:50:55 bicatali Exp $
 
 EAPI=7
 

--- a/sci-libs/libticalcs2/libticalcs2-9999.ebuild
+++ b/sci-libs/libticalcs2/libticalcs2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/sci-libs/libticalcs2/libticalcs2-1.1.8.ebuild,v 1.1 2013/07/09 16:50:55 bicatali Exp $
 

--- a/sci-libs/libticonv/libticonv-9999.ebuild
+++ b/sci-libs/libticonv/libticonv-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/sci-libs/libticonv/libticonv-1.1.4.ebuild,v 1.1 2013/07/09 16:43:59 bicatali Exp $
 

--- a/sci-libs/libticonv/libticonv-9999.ebuild
+++ b/sci-libs/libticonv/libticonv-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/sci-libs/libticonv/libticonv-1.1.4.ebuild,v 1.1 2013/07/09 16:43:59 bicatali Exp $
 
 EAPI=7
 

--- a/sci-libs/libtifiles2/libtifiles2-9999.ebuild
+++ b/sci-libs/libtifiles2/libtifiles2-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/sci-libs/libtifiles2/libtifiles2-1.1.6-r1.ebuild,v 1.2 2014/07/15 14:37:09 jlec Exp $
 
 EAPI=7
 

--- a/sci-libs/libtifiles2/libtifiles2-9999.ebuild
+++ b/sci-libs/libtifiles2/libtifiles2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/sci-libs/libtifiles2/libtifiles2-1.1.6-r1.ebuild,v 1.2 2014/07/15 14:37:09 jlec Exp $
 

--- a/sys-apps/inxi/inxi-2.2.19.ebuild
+++ b/sys-apps/inxi/inxi-2.2.19.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-apps/inxi/inxi-2.2.19.ebuild
+++ b/sys-apps/inxi/inxi-2.2.19.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/sys-apps/yaourt/yaourt-1.2.2.ebuild
+++ b/sys-apps/yaourt/yaourt-1.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-apps/yaourt/yaourt-1.2.2.ebuild
+++ b/sys-apps/yaourt/yaourt-1.2.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/sys-boot/grub-efi/grub-efi-0.97-r84.ebuild
+++ b/sys-boot/grub-efi/grub-efi-0.97-r84.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 # XXX: we need to review menu.lst vs grub.conf handling.  We've been converting
 #      all systems to grub.conf (and symlinking menu.lst to grub.conf), but

--- a/sys-boot/grub-efi/grub-efi-0.97-r84.ebuild
+++ b/sys-boot/grub-efi/grub-efi-0.97-r84.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-devel/gdb/gdb-7.1.ebuild
+++ b/sys-devel/gdb/gdb-7.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit flag-o-matic eutils
 

--- a/sys-devel/gdb/gdb-7.1.ebuild
+++ b/sys-devel/gdb/gdb-7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-devel/ucc/ucc-1.1-r0.ebuild
+++ b/sys-devel/ucc/ucc-1.1-r0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/sys-devel/ucc/ucc-1.1-r0.ebuild
+++ b/sys-devel/ucc/ucc-1.1-r0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-fs/coda/coda-7.0.5.ebuild
+++ b/sys-fs/coda/coda-7.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/sys-fs/f2fs-tools/f2fs-tools-9999.ebuild
+++ b/sys-fs/f2fs-tools/f2fs-tools-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-fs/f2fs-tools/f2fs-tools-9999.ebuild
+++ b/sys-fs/f2fs-tools/f2fs-tools-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/sys-fs/jmtpfs/jmtpfs-0.5.ebuild
+++ b/sys-fs/jmtpfs/jmtpfs-0.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/sys-fs/jmtpfs/jmtpfs-0.5.ebuild
+++ b/sys-fs/jmtpfs/jmtpfs-0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-fs/yaffs2utils/yaffs2utils-0.3.0.ebuild
+++ b/sys-fs/yaffs2utils/yaffs2utils-0.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-fs/yaffs2utils/yaffs2utils-0.3.0.ebuild
+++ b/sys-fs/yaffs2utils/yaffs2utils-0.3.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999-r1.ebuild
+++ b/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999-r1.ebuild
+++ b/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999.ebuild
+++ b/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/net-libs/libssh/libssh-9999.ebuild,v 1.5 2011/05/03 11:32:59 scarabeus Exp $
 
 # Maintainer: check IUSE-defaults at DefineOptions.cmake
 

--- a/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999.ebuild
+++ b/sys-fs/zfs-auto-snapshot/zfs-auto-snapshot-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/net-libs/libssh/libssh-9999.ebuild,v 1.5 2011/05/03 11:32:59 scarabeus Exp $
 

--- a/sys-kernel/e-sources/e-sources-3.18.14.ebuild
+++ b/sys-kernel/e-sources/e-sources-3.18.14.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 K_DEBLOB_AVAILABLE="1"

--- a/sys-kernel/e-sources/e-sources-3.18.14.ebuild
+++ b/sys-kernel/e-sources/e-sources-3.18.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-kernel/e-sources/e-sources-4.0.9.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.0.9.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 K_DEBLOB_AVAILABLE="1"

--- a/sys-kernel/e-sources/e-sources-4.0.9.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-kernel/e-sources/e-sources-4.1.12.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.1.12.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 K_DEBLOB_AVAILABLE="1"

--- a/sys-kernel/e-sources/e-sources-4.1.12.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.1.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-kernel/e-sources/e-sources-4.2.5.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.2.5.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 K_DEBLOB_AVAILABLE="1"

--- a/sys-kernel/e-sources/e-sources-4.2.5.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-kernel/e-sources/e-sources-4.5.2.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.5.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 K_DEBLOB_AVAILABLE="0"

--- a/sys-kernel/e-sources/e-sources-4.5.2.ebuild
+++ b/sys-kernel/e-sources/e-sources-4.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.29.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.29.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.44.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.44.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.52.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.52.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.65.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.65.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.74.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.74.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.10.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.11.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.12.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.13.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.14.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.15.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.3.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.4-r1.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.4-r2.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.4.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.5-r1.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.5.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.6.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.7.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.8-r1.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.8.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/projectc-sources/projectc-sources-5.10.9.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.10.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.1.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.10.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.12.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.14.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.2.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.3-r3.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.3-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.3.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.4.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.5-r1.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.5.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.6.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.8.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.9.ebuild
+++ b/sys-kernel/xanmod-cacule-sources/xanmod-cacule-sources-5.10.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-uksm-sources/xanmod-uksm-sources-5.10.14.ebuild
+++ b/sys-kernel/xanmod-uksm-sources/xanmod-uksm-sources-5.10.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-kernel/xanmod-uksm-sources/xanmod-uksm-sources-5.10.15.ebuild
+++ b/sys-kernel/xanmod-uksm-sources/xanmod-uksm-sources-5.10.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/sys-libs/elog-functions/elog-functions-0.0.2.ebuild
+++ b/sys-libs/elog-functions/elog-functions-0.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-libs/elog-functions/elog-functions-0.0.2.ebuild
+++ b/sys-libs/elog-functions/elog-functions-0.0.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit multilib
 

--- a/sys-libs/libixp/libixp-9999.ebuild
+++ b/sys-libs/libixp/libixp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/sys-libs/libixp/libixp-9999.ebuild
+++ b/sys-libs/libixp/libixp-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit toolchain-funcs mercurial
 

--- a/virtual/linux-sources/linux-sources-1.ebuild
+++ b/virtual/linux-sources/linux-sources-1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/virtual/linux-sources/linux-sources-1.ebuild
+++ b/virtual/linux-sources/linux-sources-1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 

--- a/virtual/openvg/openvg-1.1.ebuild
+++ b/virtual/openvg/openvg-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/virtual/openvg/openvg-1.1.ebuild
+++ b/virtual/openvg/openvg-1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/www-plugins/115upload/115upload-1.5.7.0.ebuild
+++ b/www-plugins/115upload/115upload-1.5.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/www-plugins/115upload/115upload-1.5.7.0.ebuild
+++ b/www-plugins/115upload/115upload-1.5.7.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 

--- a/www-plugins/aliedit/aliedit-1.0.3.20.ebuild
+++ b/www-plugins/aliedit/aliedit-1.0.3.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/www-plugins/aliedit/aliedit-1.0.3.20.ebuild
+++ b/www-plugins/aliedit/aliedit-1.0.3.20.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=6
 

--- a/www-plugins/upeditor/upeditor-1.0.0.6.ebuild
+++ b/www-plugins/upeditor/upeditor-1.0.0.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
 # $Header: $
 

--- a/www-plugins/upeditor/upeditor-1.0.0.6.ebuild
+++ b/www-plugins/upeditor/upeditor-1.0.0.6.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v3
-# $Header: $
 
 EAPI=6
 

--- a/www-servers/bashttpd/bashttpd-0.1-r1.ebuild
+++ b/www-servers/bashttpd/bashttpd-0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/www-servers/bashttpd/bashttpd-0.1-r1.ebuild
+++ b/www-servers/bashttpd/bashttpd-0.1-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/www-servers/tengine/tengine-2.0.3.ebuild
+++ b/www-servers/tengine/tengine-2.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/www-servers/tengine/tengine-2.0.3.ebuild
+++ b/www-servers/tengine/tengine-2.0.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/x11-apps/xcur2png/xcur2png-0.7.1.ebuild
+++ b/x11-apps/xcur2png/xcur2png-0.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/x11-libs/libvdpau-va-gl/libvdpau-va-gl-9999.ebuild
+++ b/x11-libs/libvdpau-va-gl/libvdpau-va-gl-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-libs/libvdpau-va-gl/libvdpau-va-gl-9999.ebuild
+++ b/x11-libs/libvdpau-va-gl/libvdpau-va-gl-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/x11-libs/xcb-imdkit/xcb-imdkit-1.0.0.ebuild
+++ b/x11-libs/xcb-imdkit/xcb-imdkit-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/x11-libs/xcb-imdkit/xcb-imdkit-99999999999.ebuild
+++ b/x11-libs/xcb-imdkit/xcb-imdkit-99999999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/x11-misc/9menu/9menu-1.8.ebuild
+++ b/x11-misc/9menu/9menu-1.8.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/x11-misc/9menu/9menu-1.8.ebuild
+++ b/x11-misc/9menu/9menu-1.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-misc/fqterm/fqterm-0.9.8.3.4.ebuild
+++ b/x11-misc/fqterm/fqterm-0.9.8.3.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-misc/fqterm/fqterm-0.9.8.3.4.ebuild
+++ b/x11-misc/fqterm/fqterm-0.9.8.3.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/x11-misc/fqterm/fqterm-9999.ebuild
+++ b/x11-misc/fqterm/fqterm-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-misc/fqterm/fqterm-9999.ebuild
+++ b/x11-misc/fqterm/fqterm-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/x11-misc/i3lock-color/i3lock-color-9999.ebuild
+++ b/x11-misc/i3lock-color/i3lock-color-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-misc/i3lock-fancy/i3lock-fancy-9999.ebuild
+++ b/x11-misc/i3lock-fancy/i3lock-fancy-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-misc/lightdm-slick-greeter/lightdm-slick-greeter-1.4.1.ebuild
+++ b/x11-misc/lightdm-slick-greeter/lightdm-slick-greeter-1.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-misc/lightdm-slick-greeter/lightdm-slick-greeter-9999.ebuild
+++ b/x11-misc/lightdm-slick-greeter/lightdm-slick-greeter-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-misc/synergy/synergy-1.10.3.ebuild
+++ b/x11-misc/synergy/synergy-1.10.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-plugins/vicious/vicious-2.1.3.ebuild
+++ b/x11-plugins/vicious/vicious-2.1.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=7
 

--- a/x11-plugins/vicious/vicious-2.1.3.ebuild
+++ b/x11-plugins/vicious/vicious-2.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-plugins/vicious/vicious-9999.ebuild
+++ b/x11-plugins/vicious/vicious-9999.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI=5
 

--- a/x11-plugins/vicious/vicious-9999.ebuild
+++ b/x11-plugins/vicious/vicious-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-terms/termite/termite-9999.ebuild
+++ b/x11-terms/termite/termite-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/x11-terms/vte-ng/vte-ng-9999.ebuild
+++ b/x11-terms/vte-ng/vte-ng-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/x11-themes/gnome-themes-egtk/gnome-themes-egtk-1.0.ebuild
+++ b/x11-themes/gnome-themes-egtk/gnome-themes-egtk-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-themes/gnome-themes-egtk/gnome-themes-egtk-1.0.ebuild
+++ b/x11-themes/gnome-themes-egtk/gnome-themes-egtk-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EAPI="2"
 

--- a/x11-themes/gnome-themes-ubuntu/gnome-themes-ubuntu-0.6.1.ebuild
+++ b/x11-themes/gnome-themes-ubuntu/gnome-themes-ubuntu-0.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-themes/gnome-themes-ubuntu/gnome-themes-ubuntu-0.6.1.ebuild
+++ b/x11-themes/gnome-themes-ubuntu/gnome-themes-ubuntu-0.6.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="GNOME themes from Ubuntu"
 HOMEPAGE="http://www.ubuntu.com"

--- a/x11-themes/lxice/lxice-0.1.0.ebuild
+++ b/x11-themes/lxice/lxice-0.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-themes/lxice/lxice-0.1.0.ebuild
+++ b/x11-themes/lxice/lxice-0.1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="LXDE theme for IceWM"
 HOMEPAGE="http://lxde.sf.net/"

--- a/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.0.ebuild
+++ b/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Icon themes for smplayer"
 HOMEPAGE="http://smplayer.sourceforge.net/"

--- a/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.0.ebuild
+++ b/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.1.ebuild
+++ b/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 DESCRIPTION="Icon themes for smplayer"
 HOMEPAGE="http://smplayer.sourceforge.net/"

--- a/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.1.ebuild
+++ b/x11-themes/smplayer-themes-nonfree/smplayer-themes-nonfree-0.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-wm/9wm/9wm-1.1.ebuild
+++ b/x11-wm/9wm/9wm-1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 inherit eutils
 

--- a/x11-wm/9wm/9wm-1.1.ebuild
+++ b/x11-wm/9wm/9wm-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/x11-wm/chamferwm/chamferwm-9999.ebuild
+++ b/x11-wm/chamferwm/chamferwm-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/x11-wm/i3-gaps/i3-gaps-4.18.1.ebuild
+++ b/x11-wm/i3-gaps/i3-gaps-4.18.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7


### PR DESCRIPTION
update copyright header --> https://www.gentoo.org/glep/glep-0076.html
```bash
copybump $(git ls-files '*.ebuild')
```

clean header:
```bash
sed -i -r -e '/\$Header/d' $(git ls-files '*.ebuild')
```