### PR TITLE
fcitx5: make wayland dependency optional

### DIFF
--- a/app-i18n/fcitx5/fcitx5-5.0.6.ebuild
+++ b/app-i18n/fcitx5/fcitx5-5.0.6.ebuild
@@ -30,8 +30,10 @@ RDEPEND="dev-libs/glib:2
 	virtual/libintl
 	x11-libs/libxkbcommon[X]
 	x11-libs/libX11
-	dev-libs/wayland
-	dev-libs/wayland-protocols
+	wayland? (
+		dev-libs/wayland
+		dev-libs/wayland-protocols
+	)
 	x11-libs/libXfixes
 	x11-libs/libXinerama
 	x11-libs/libXrender


### PR DESCRIPTION
wayland should not be pulled if `-wayland` is specified.