### PR TITLE
Add a github-action to generate deps table

### DIFF
--- a/.github/workflows/generate-deps-relation-r1.yml
+++ b/.github/workflows/generate-deps-relation-r1.yml
@@ -1,0 +1,32 @@
+name: Generate the dependencies table
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v2
+        with:
+          ref: deps-table
+      - name: Fetch gentoo-zh repo
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: gentoo-zh
+      - name: Update packages relation
+        id: update_relation
+        shell: bash
+        run: ./update-relation.sh
+      - name: Push changes
+        if: ${{ steps.update_relation.outputs.state == 'changed' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: deps-table

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ DO NOT BREAK PEOPLE'S SYSTEM
 
 follow rule no.1 and no.2
 
+# the dependencies table
+
+https://github.com/microcai/gentoo-zh/blob/deps-table/relation.md
+
 # commit message
 
 * for non-version bump commit, commit message should be like this:
@@ -50,5 +54,5 @@ follow rule no.1 and no.2
   `KEYWORDS="alpha amd64 arm hppa ia64 ppc mips ~s390 ~sh sparc x86 ~x86-fbsd"`
 
   But please don't abuse this exception. It must be a pure font package.
-  
+
   # See wiki for some package not working


### PR DESCRIPTION
Every time when the 'master' branch be pushed, the action checkouts
the 'deps-table' branch and execute shell to generate deps table of
packages of this overlay.

The generated table will be pushed to the 'deps-table' branch.

Signed-off-by: bekcpear <i@bitbili.net>