### PR TITLE
sys-kernel: update to new depend pahole

### DIFF
--- a/sys-kernel/projectc-sources/projectc-sources-5.12.8.ebuild
+++ b/sys-kernel/projectc-sources/projectc-sources-5.12.8.ebuild
@@ -11,7 +11,7 @@ ETYPE="sources"
 IUSE="uksm cjktty pds +bmq muqss"
 REQUIRED_USE="^^ ( pds bmq muqss )"
 DEPEND="app-arch/cpio
-        dev-util/dwarves
+        dev-util/pahole
         dev-libs/libbpf"
 
 inherit kernel-2-src-prepare-overlay

--- a/sys-kernel/xanmod-hybird/xanmod-hybird-5.12.8.ebuild
+++ b/sys-kernel/xanmod-hybird/xanmod-hybird-5.12.8.ebuild
@@ -10,7 +10,7 @@ ETYPE="sources"
 IUSE="uksm cjktty +xanmod cacule"
 REQUIRED_USE="^^ ( xanmod cacule )"
 DEPEND="app-arch/cpio
-        dev-util/dwarves
+        dev-util/pahole
         dev-libs/libbpf
 "
 RDEPEND="!sys-kernel/xanmod-sources"


### PR DESCRIPTION
Gentoo official [commit](https://github.com/gentoo-mirror/gentoo/commit/56a33b831f6ca1afd71a0e66f397c0ff5dcc1a97): dev-util/dwarves: Rename package to dev-util/pahole