### PR TITLE
generate-deps-relation-r1.yml: force to push

### DIFF
--- a/.github/workflows/generate-deps-relation-r1.yml
+++ b/.github/workflows/generate-deps-relation-r1.yml
@@ -1,4 +1,4 @@
-name: Generate the dependencies table
+name: dependencies table
 on:
   push:
     branches:
@@ -30,3 +30,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: deps-table
+          force: true


### PR DESCRIPTION
sometime when some PRs/commits pushed at the same time, the
automaticly generated commits may conflict when pushed to
branch deps-table, so force it

Signed-off-by: bekcpear <i@bitbili.net>