### PR TITLE
app-i18n/fcitx5-rime: fix a build error

### DIFF
--- a/app-i18n/fcitx5-rime/fcitx5-rime-5.0.6.ebuild
+++ b/app-i18n/fcitx5-rime/fcitx5-rime-5.0.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake xdg
+inherit xdg cmake
 
 DESCRIPTION="Rime Support for Fcitx5"
 HOMEPAGE="https://github.com/fcitx/fcitx5-rime"

--- a/app-i18n/fcitx5-rime/fcitx5-rime-9999.ebuild
+++ b/app-i18n/fcitx5-rime/fcitx5-rime-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake xdg
+inherit xdg cmake
 
 DESCRIPTION="Rime Support for Fcitx5"
 HOMEPAGE="https://github.com/fcitx/fcitx5-rime"


### PR DESCRIPTION
Fix a build error introduced in
a5840fd96a88f6942a9d295cbc33b974157af0b2.

If cmake is inherited before xdg and cmake_src_prepare is not called
explicitly, cmake_src_prepare is not called, leading to the failure
of cmake_src_prepare.