### PR TITLE
net-proxy/v2ray: fix typo of `REPLACING_VERSIONS`

### DIFF
--- a/net-proxy/v2ray/v2ray-4.40.1.ebuild
+++ b/net-proxy/v2ray/v2ray-4.40.1.ebuild
@@ -609,7 +609,7 @@ RDEPEND="
 
 S="${WORKDIR%/}/${PN}-core-${PV}"
 pkg_pretend() {
-	if [[ -z "${REPLAING_VERSIONS}" ]]; then
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		cngoproxyset=0
 		if [[ -e "${ROOT}"/etc/portage/mirrors ]]; then
 			grep '^\s*goproxy\s' "${ROOT}"/etc/portage/mirrors >/dev/null 2>&1


### PR DESCRIPTION
https://github.com/microcai/gentoo-zh/issues/1163

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: bekcpear <i@bitbili.net>