### PR TITLE
x11-misc/i3lock-color: remove keyword in live package

### DIFF
--- a/x11-misc/i3lock-color/i3lock-color-9999.ebuild
+++ b/x11-misc/i3lock-color/i3lock-color-9999.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="An improved i3lock"
 HOMEPAGE="https://github.com/chrjguill/i3lock-color"
 EGIT_REPO_URI="https://github.com/chrjguill/i3lock-color.git"
 LICENSE="BSD"
-KEYWORDS="~amd64"
+KEYWORDS=""
 SRC_URI=""
 
 SLOT="0"


### PR DESCRIPTION
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>