### PR TITLE
dev-python/fuo-netease: fix dependency

### DIFF
--- a/dev-python/fuo-netease/fuo-netease-0.7.1-r1.ebuild
+++ b/dev-python/fuo-netease/fuo-netease-0.7.1-r1.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="~amd64"
 RDEPEND="
 	dev-python/marshmallow[${PYTHON_USEDEP}]
 	dev-python/requests[${PYTHON_USEDEP}]
-	dev-python/beautifulsoup[${PYTHON_USEDEP}]
+	dev-python/beautifulsoup4[${PYTHON_USEDEP}]
 	dev-python/pycryptodome[${PYTHON_USEDEP}]
 "
 


### PR DESCRIPTION
change the dependency from "dev-python/beautifulsoup", which is missing
in upstream gentoo repo, to "dev-python/beautifulsoup4"
related issue: #1191 