### PR TITLE
net-fs/ksmbd-tools: fix file transfer stuck at 99%

### DIFF
--- a/net-fs/ksmbd-tools/files/ksmbd-tools-fix-file-transfer-stuck-at-99.patch
+++ b/net-fs/ksmbd-tools/files/ksmbd-tools-fix-file-transfer-stuck-at-99.patch
@@ -1,0 +1,54 @@
+From 7232230911c02f81cb50b38f47ccf7100dd066f9 Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Sun, 21 Nov 2021 10:16:24 +0900
+Subject: [PATCH] ksmbd-tools: fix file transfer stuck at 99%
+
+When user set share name included upper character in smb.conf,
+Windows File transfer will stuck at 99%. When copying file, windows send
+SRVSVC GET_SHARE_INFO command to ksmbd server. but ksmbd store after
+converting share name from smb.conf to lower cases. So ksmbd.mountd
+can't not find share and return error to windows client.
+This patch find share using name converted share name from client to
+lower cases.
+
+Reported-by: Olha Cherevyk <olha.cherevyk@gmail.com>
+Tested-by: Oleksandr Natalenko <oleksandr@natalenko.name>
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ mountd/rpc_srvsvc.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/mountd/rpc_srvsvc.c b/mountd/rpc_srvsvc.c
+index 8608b2e..f3b4d06 100644
+--- a/mountd/rpc_srvsvc.c
++++ b/mountd/rpc_srvsvc.c
+@@ -169,8 +169,11 @@ static int srvsvc_share_get_info_invoke(struct ksmbd_rpc_pipe *pipe,
+ {
+ 	struct ksmbd_share *share;
+ 	int ret;
++	gchar *share_name;
+ 
+-	share = shm_lookup_share(STR_VAL(hdr->share_name));
++	share_name = g_ascii_strdown(STR_VAL(hdr->share_name),
++			strlen(STR_VAL(hdr->share_name)));
++	share = shm_lookup_share(share_name);
+ 	if (!share)
+ 		return 0;
+ 
+@@ -188,9 +191,12 @@ static int srvsvc_share_get_info_invoke(struct ksmbd_rpc_pipe *pipe,
+ 	}
+ 
+ 	if (ret != 0) {
++		gchar *server_name = g_ascii_strdown(STR_VAL(hdr->server_name),
++				strlen(STR_VAL(hdr->server_name)));
++
+ 		ret = shm_lookup_hosts_map(share,
+ 					   KSMBD_SHARE_HOSTS_DENY_MAP,
+-					   STR_VAL(hdr->server_name));
++					   server_name);
+ 		if (ret == 0) {
+ 			put_ksmbd_share(share);
+ 			return 0;
+-- 
+2.32.0
+

--- a/net-fs/ksmbd-tools/ksmbd-tools-3.4.2-r2.ebuild
+++ b/net-fs/ksmbd-tools/ksmbd-tools-3.4.2-r2.ebuild
@@ -30,6 +30,7 @@ BDEPEND=""
 
 PATCHES=(
 	"${FILESDIR}/${PN}-Standardize-exit-codes.patch"
+	"${FILESDIR}/${PN}-fix-file-transfer-stuck-at-99.patch"
 )
 
 DOCS=( AUTHORS README Documentation/configuration.txt )


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: NoName <458892+aieu@users.noreply.github.com>