### PR TITLE
net-proxy/clash: remove systemd USE flag

### DIFF
--- a/net-proxy/clash/clash-1.8.0.ebuild
+++ b/net-proxy/clash/clash-1.8.0.ebuild
@@ -144,7 +144,7 @@ RESTRICT="mirror"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm ~arm64 ~mips ~ppc64 ~s390 ~x86"
-IUSE="geoip systemd"
+IUSE="geoip"
 
 BDEPEND=">=dev-lang/go-1.16.2:="
 RDEPEND="!arm64? (


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Anonymous <458892+aieu@users.noreply.github.com>