### PR TITLE
app-editors/typora: use QA_PREBUILD="*" to make gentoo happy

### DIFF
--- a/app-editors/typora/typora-0.11.18.ebuild
+++ b/app-editors/typora/typora-0.11.18.ebuild
@@ -23,16 +23,7 @@ RDEPEND="
 	${DEPEND}"
 BDEPEND=""
 
-QA_PRESTRIPPED="
-	/opt/${PN}/share/typora/Typora
-	/opt/${PN}/share/typora/chrome-sandbox
-	/opt/${PN}/share/typora/.*\.so
-	/opt/${PN}/share/typora/.*/.*\.so
-	/opt/${PN}/share/typora/resources/app/node_modules/vscode-ripgrep/bin/rg
-	/opt/${PN}/share/typora/resources/app/node_modules/pathwatcher/build/Release/pathwatcher.node
-	/opt/${PN}/share/typora/resources/app/node_modules/spellchecker/build/Release/spellchecker.node
-	/opt/${PN}/share/typora/resources/app/node_modules/spellchecker/node_modules/cld/build/Release/cld.node
-"
+QA_PREBUILT="*"
 
 src_unpack() {
 	default

--- a/app-editors/typora/typora-1.0.2.ebuild
+++ b/app-editors/typora/typora-1.0.2.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	${DEPEND}"
 BDEPEND=""
 
-QA_PREBUILD="*"
+QA_PREBUILT="*"
 
 src_unpack() {
 	default

--- a/sci-chemistry/vesta/vesta-3.5.5.ebuild
+++ b/sci-chemistry/vesta/vesta-3.5.5.ebuild
@@ -28,7 +28,7 @@ BDEPEND=""
 
 S="${WORKDIR}/VESTA-gtk3"
 
-QA_PREBUILD="*"
+QA_PREBUILT="*"
 
 src_install() {
 	insinto /opt/VESTA

--- a/sci-chemistry/vesta/vesta-3.5.7.ebuild
+++ b/sci-chemistry/vesta/vesta-3.5.7.ebuild
@@ -28,7 +28,7 @@ BDEPEND=""
 
 S="${WORKDIR}/VESTA-gtk3"
 
-QA_PREBUILD="*"
+QA_PREBUILT="*"
 
 src_install() {
 	insinto /opt/VESTA


### PR DESCRIPTION
according to https://devmanual.gentoo.org/eclass-reference/ebuild/index.html
it is enough to set QA_PREBUILD="*" to suppress all the warnings
about prebuild packages