### PR TITLE
app-i18n/fictx5: add a missing dependency used by classui library

### DIFF
--- a/app-i18n/fcitx5/fcitx5-5.0.10.ebuild
+++ b/app-i18n/fcitx5/fcitx5-5.0.10.ebuild
@@ -56,10 +56,13 @@ RDEPEND="dev-libs/glib:2
 	app-text/iso-codes
 	app-i18n/unicode-cldr
 	dev-libs/libxml2
-	dev-libs/libevent"
+	dev-libs/libevent
+	x11-libs/gdk-pixbuf:2
+"
 DEPEND="${RDEPEND}
 	kde-frameworks/extra-cmake-modules:5
-	virtual/pkgconfig"
+	virtual/pkgconfig
+"
 
 src_prepare() {
 	pwd


### PR DESCRIPTION
Fix app-i18n/fcitx5-5.0.10 fails to compile https://github.com/microcai/gentoo-zh/issues/1368