### PR TITLE
x11-term/9wm: fix 9wm don't respect CFALGS and LDFLAGS

### DIFF
--- a/x11-wm/9wm/9wm-1.1.ebuild
+++ b/x11-wm/9wm/9wm-1.1.ebuild
@@ -19,6 +19,7 @@ RDEPEND="x11-libs/libX11
 	x11-terms/xterm"
 
 src_compile() {
+	export CC="${CC} ${CFLAGS} ${LDFLAGS}"
 	emake -f Makefile.no-imake || die "emake error"
 }
 


### PR DESCRIPTION
fix https://github.com/microcai/gentoo-zh/issues/1434