### PR TITLE
x11-misc/9menu: fix 9menu don't respect CFALGS and LDFLAGS

### DIFF
--- a/x11-misc/9menu/9menu-1.8.ebuild
+++ b/x11-misc/9menu/9menu-1.8.ebuild
@@ -16,6 +16,11 @@ IUSE=""
 
 RDEPEND="x11-libs/libX11"
 
+src_prepare() {
+	default
+	eapply "${FILESDIR}/fix-ignore-cflags-and-ldflags.patch"
+}
+
 src_compile() {
 	emake -f Makefile.noimake || die "emake error"
 }

--- a/x11-misc/9menu/files/fix-ignore-cflags-and-ldflags.patch
+++ b/x11-misc/9menu/files/fix-ignore-cflags-and-ldflags.patch
@@ -1,0 +1,17 @@
+diff --git a/Makefile.noimake b/Makefile.noimake
+index 3c74f8b..73e3efd 100644
+--- a/Makefile.noimake
++++ b/Makefile.noimake
+@@ -5,9 +5,9 @@
+ # Arnold Robbins
+ # arnold@skeeve.atl.ga.us
+ 
+-CC = gcc
+-CFLAGS = -g -O
++CC ?= gcc
++CFLAGS ?= -g -O
+ LIBS = -lX11
+ 
+ 9menu: 9menu.c
+-	$(CC) $(CFLAGS) 9menu.c $(LIBS) -o 9menu
++	$(CC) $(CFLAGS) $(LDFLAGS) 9menu.c $(LIBS) -o 9menu


### PR DESCRIPTION
fix https://github.com/microcai/gentoo-zh/issues/1431