### PR TITLE
sys-libs/elog-functions: fix command get_libdir not found

### DIFF
--- a/sys-libs/elog-functions/elog-functions-0.0.2.ebuild
+++ b/sys-libs/elog-functions/elog-functions-0.0.2.ebuild
@@ -16,6 +16,6 @@ RDEPEND="app-shells/bash"
 S="${WORKDIR}"
 
 src_install() {
-	insinto /usr/$(get_libdir)/misc
+	insinto /usr/$(get_abi_LIBDIR)/misc
 	doins "${FILESDIR}/${PN}.sh"
 }


### PR DESCRIPTION
fix https://github.com/microcai/gentoo-zh/issues/1428