### PR TITLE
dev-libs/lunar-date: add missing dependencies

### DIFF
--- a/dev-libs/lunar-date/lunar-date-3.0.0.ebuild
+++ b/dev-libs/lunar-date/lunar-date-3.0.0.ebuild
@@ -17,6 +17,7 @@ IUSE="+dbus doc introspection test"
 RDEPEND=">=dev-python/pygobject-2.11.5"
 
 DEPEND="${RDEPEND}
+	dev-util/gdbus-codegen
 	sys-devel/gettext
 	virtual/pkgconfig
 	>=dev-util/intltool-0.35


### PR DESCRIPTION
https://bugs.gentoo.org/825998

close #1384

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Anonymous <458892+aieu@users.noreply.github.com>