### PR TITLE
sci-chemistry/vesta: fix 3.5.7 undefined symbol

### DIFF
--- a/sci-chemistry/vesta/vesta-3.5.7-r1.ebuild
+++ b/sci-chemistry/vesta/vesta-3.5.7-r1.ebuild
@@ -18,7 +18,7 @@ RESTRICT="mirror strip"
 
 DEPEND=""
 RDEPEND="
-	x11-libs/gtk+
+	x11-libs/gtk+[wayland]
 	virtual/glu
 	dev-util/desktop-file-utils
 	x11-libs/libXtst


### PR DESCRIPTION
vesta 3.5.7 need gdk_wayland_display_get_type to be defined,
which is provided by gtk+ with wayland enabled