### PR TITLE
app-i18n/mozc: depend on older protobuf

### DIFF
--- a/app-i18n/mozc/mozc-2.26.4220_p20201212102434_p20201219202429-r1.ebuild
+++ b/app-i18n/mozc/mozc-2.26.4220_p20201212102434_p20201219202429-r1.ebuild
@@ -48,7 +48,7 @@ REQUIRED_USE="|| ( emacs fcitx4 fcitx5 ibus )"
 RESTRICT="!test? ( test )"
 
 BDEPEND="$(python_gen_any_dep 'dev-python/six[${PYTHON_USEDEP}]')
-	>=dev-libs/protobuf-3.0.0
+	<dev-libs/protobuf-3.19
 	dev-util/gyp
 	dev-util/ninja
 	virtual/pkgconfig
@@ -56,7 +56,7 @@ BDEPEND="$(python_gen_any_dep 'dev-python/six[${PYTHON_USEDEP}]')
 	fcitx4? ( sys-devel/gettext )
 	fcitx5? ( sys-devel/gettext )"
 DEPEND="=dev-cpp/abseil-cpp-20200923*[cxx17(+)]
-	>=dev-libs/protobuf-3.0.0:=
+	<dev-libs/protobuf-3.19:=
 	fcitx4? (
 		app-i18n/fcitx:4
 		virtual/libintl


### PR DESCRIPTION
[main tree有更新](https://github.com/gentoo/gentoo/commit/c4c3366c68e5d9313db9c41b76c8641c52bd10aa) 我也就直接在这跟进了