### PR TITLE
app-backup/snapper-gui: add new package

### DIFF
--- a/app-backup/snapper-gui/metadata.xml
+++ b/app-backup/snapper-gui/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>chn@chn.moe</email>
+		<name>Haonan Chen</name>
+	</maintainer>
+</pkgmetadata>

--- a/app-backup/snapper-gui/snapper-gui-201020.ebuild
+++ b/app-backup/snapper-gui/snapper-gui-201020.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{8..10} )
+DISTUTILS_SINGLE_IMPL=y
+inherit distutils-r1 git-r3
+
+DESCRIPTION="GUI for snapper, a tool for Linux filesystem snapshot management"
+HOMEPAGE="https://github.com/ricardomv/snapper-gui"
+KEYWORDS="~amd64"
+EGIT_REPO_URI="https://github.com/ricardomv/${PN}.git"
+EGIT_COMMIT=f0c67ab
+
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+DEPEND=""
+RDEPEND="
+	${DEPEND}
+	app-backup/snapper
+	$(python_gen_cond_dep 'dev-python/dbus-python[${PYTHON_USEDEP}] dev-python/pygobject[${PYTHON_USEDEP}]')
+	x11-libs/gtksourceview:3.0
+"
+
+src_prepare() {
+	sed -i 's/Utilities;/Utility;/' "${S}/snapper-gui.desktop"
+	default
+}


### PR DESCRIPTION
有两件事情可能需要大佬注意：

1. `snapper-gui` 本身没有明确的版本号并且也没有在活跃地开发，因此我使用最后一次 commit 的日期作为版本号。相比于直接使用 `9999`，这样的好处是，如果将来有新的 commit 出现，可以更方便地让用户知道有更新了，`emerge -avuDN @world` 时也会触发更新。我不确定这是否符合规范。
2. `snapper-gui` 在构建的时候需要用到 `python`，但 python 相关的 eclass 看起来都非常复杂，我不确定我使用的姿势是否正确（尽管本地测试是没问题的），最好再仔细检查一下。