### PR TITLE
net-proxy/Xray: do not automatically rebuild after go update

### DIFF
--- a/net-proxy/Xray/Xray-1.4.3.ebuild
+++ b/net-proxy/Xray/Xray-1.4.3.ebuild
@@ -409,7 +409,7 @@ SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~x86"
 IUSE=""
 
-BDEPEND=">=dev-lang/go-1.16.2:="
+BDEPEND=">=dev-lang/go-1.16.2"
 RDEPEND="app-misc/ca-certificates"
 
 S="${WORKDIR}/${PN}-core-${PV}"

--- a/net-proxy/Xray/Xray-1.4.4.ebuild
+++ b/net-proxy/Xray/Xray-1.4.4.ebuild
@@ -415,7 +415,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 IUSE=""
 
-BDEPEND=">=dev-lang/go-1.16.2:="
+BDEPEND=">=dev-lang/go-1.16.2"
 RDEPEND="app-misc/ca-certificates"
 
 S="${WORKDIR}/${PN}-core-${PV}"

--- a/net-proxy/Xray/Xray-1.4.5.ebuild
+++ b/net-proxy/Xray/Xray-1.4.5.ebuild
@@ -415,7 +415,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 IUSE=""
 
-BDEPEND=">=dev-lang/go-1.16.2:="
+BDEPEND=">=dev-lang/go-1.16.2"
 RDEPEND="app-misc/ca-certificates"
 
 S="${WORKDIR}/${PN}-core-${PV}"


### PR DESCRIPTION
Accroding to other packages depende on dev-lang/go (such as docker),
it is not neccecary to rebuild the package after go update, unless user
manually trigger it by @golang-rebuild.
If `>=dev-lang/go-1.16.2:=` is specified, the package will be rebuilt
twice after go update (once automatically and another manually
triggered by @golang-rebuild).