### PR TITLE
sys-libs/glibc: import a new patch

### DIFF
--- a/sys-libs/glibc/files/clangify/0021-dont-check-gcc-personality-in-gcc_s.patch
+++ b/sys-libs/glibc/files/clangify/0021-dont-check-gcc-personality-in-gcc_s.patch
@@ -1,0 +1,33 @@
+diff --git a/misc/unwind-link.c b/misc/unwind-link.c
+index ad3d02bf32..2631167756 100644
+--- a/misc/unwind-link.c
++++ b/misc/unwind-link.c
+@@ -71,8 +71,8 @@ __libc_unwind_link_get (void)
+   local.ptr___frame_state_for
+     = __libc_dlsym (local_libgcc_handle, "__frame_state_for");
+ #endif
+-  local.ptr_personality
+-    = __libc_dlsym (local_libgcc_handle, "__gcc_personality_v0");
++  //local.ptr_personality
++  //  = __libc_dlsym (local_libgcc_handle, "__gcc_personality_v0");
+   UNWIND_LINK_EXTRA_INIT
+ 
+   /* If a symbol is missing, libgcc_s has somehow been corrupted.  */
+@@ -83,7 +83,7 @@ __libc_unwind_link_get (void)
+   assert (local.ptr__Unwind_GetIP != NULL);
+ #endif
+   assert (local.ptr__Unwind_Resume != NULL);
+-  assert (local.ptr_personality != NULL);
++  //assert (local.ptr_personality != NULL);
+ 
+ #ifdef PTR_MANGLE
+   PTR_MANGLE (local.ptr__Unwind_Backtrace);
+@@ -96,7 +96,7 @@ __libc_unwind_link_get (void)
+ # if UNWIND_LINK_FRAME_STATE_FOR
+   PTR_MANGLE (local.ptr___frame_state_for);
+ # endif
+-  PTR_MANGLE (local.ptr_personality);
++  //PTR_MANGLE (local.ptr_personality);
+ #endif
+ 
+   __libc_lock_lock (lock);


### PR DESCRIPTION
  fix glibc check __gcc_personality_v0 when using llvm-libunwind,
  __gcc_personality_v0 exists in compiler-rt.