### PR TITLE
sys-kernel/xanmod-lts: Fixed a bug that caused emergency to fail when "cjk" use flag was enabled

### DIFF
--- a/sys-kernel/xanmod-lts/xanmod-lts-5.15.11-r1.ebuild
+++ b/sys-kernel/xanmod-lts/xanmod-lts-5.15.11-r1.ebuild
@@ -41,7 +41,7 @@ src_prepare() {
 		"${WORKDIR}"/patch-${PV}-xanmod${XV}
 	)
 	if use cjk; then
-		PATCHES+=("${DISTDIR}/cjktty-5.10.patch")
+		PATCHES+=("${DISTDIR}/cjktty-5.15.patch")
 	fi
 	default
 


### PR DESCRIPTION
Such as title