### PR TITLE
net-im/dingtalk: fix missing RDEPEND

### DIFF
--- a/net-im/dingtalk/dingtalk-1.2.0.140-r1.ebuild
+++ b/net-im/dingtalk/dingtalk-1.2.0.140-r1.ebuild
@@ -17,15 +17,21 @@ RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	dev-libs/libthai
+	dev-qt/qtgui
 	net-nds/openldap
+	media-video/rtmpdump
 	sys-libs/glibc
 	sys-libs/zlib
 	sys-process/procps
+	x11-libs/gtk+:2
+	x11-libs/gtk+:3
 "
 
 BDEPEND="dev-util/patchelf"
 
 DEPEND="${RDEPEND}"
+
+QA_PREBUILT="*"
 
 S=${WORKDIR}
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.30, Repoman-3.0.3