### PR TITLE
net-im/dingtalk: Fix missing RDEPENDs

### DIFF
--- a/net-im/dingtalk/dingtalk-1.2.0.140-r1.ebuild
+++ b/net-im/dingtalk/dingtalk-1.2.0.140-r1.ebuild
@@ -25,6 +25,8 @@ RDEPEND="
 	sys-process/procps
 	x11-libs/gtk+:2
 	x11-libs/gtk+:3
+	media-sound/pulseaudio
+	x11-libs/libXScrnSaver
 "
 
 BDEPEND="dev-util/patchelf"


### PR DESCRIPTION
Add missing dependencies (pulseaudio and libXScrnSaver), due to
```
$ cd /opt/apps/com.alibabainc.dingtalk/files/1.2.0-Release.140
$ ldd libQt5Multimedia.so.5
	[ ... ]
        libpulse-mainloop-glib.so.0 => [ ... ]
        libpulse.so.0 => [ ... ]
        libpulsecommon-15.0.so => [ ... ]
	[ ... ]
$ ldd libcef.so
	[ ... ]
        libXss.so.1 => [ ... ]
	[ ... ]
```

cc @vowstar