### PR TITLE
app-mobilephone/scrcpy:add dependency to virtual/libusb:1

### DIFF
--- a/app-mobilephone/scrcpy/scrcpy-1.19.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-1.19.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -29,7 +29,9 @@ IUSE=""
 
 RESTRICT="test"
 
-COMMON_DEPEND="media-libs/libsdl2
+COMMON_DEPEND="
+	virtual/libusb:1
+	media-libs/libsdl2
 	media-video/ffmpeg"
 DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}"

--- a/app-mobilephone/scrcpy/scrcpy-1.20.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-1.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Foundation
+# Copyright 2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,7 +29,9 @@ IUSE=""
 
 RESTRICT="test"
 
-COMMON_DEPEND="media-libs/libsdl2
+COMMON_DEPEND="
+	virtual/libusb:1
+	media-libs/libsdl2
 	media-video/ffmpeg"
 DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}"

--- a/app-mobilephone/scrcpy/scrcpy-1.21.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-1.21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Foundation
+# Copyright 2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,7 +29,9 @@ IUSE=""
 
 RESTRICT="test"
 
-COMMON_DEPEND="media-libs/libsdl2
+COMMON_DEPEND="
+	virtual/libusb:1
+	media-libs/libsdl2
 	media-video/ffmpeg"
 DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}"


### PR DESCRIPTION
https://bugs.gentoo.org/825814
issue https://github.com/microcai/gentoo-zh/issues/1372

repoman complains about Copyright at line 1
>RepoMan scours the neighborhood...
  ebuild.badheader              3
   app-mobilephone/scrcpy/scrcpy-1.19.ebuild: line 1: Invalid Copyright
   app-mobilephone/scrcpy/scrcpy-1.20.ebuild: line 1: Invalid Copyright
   app-mobilephone/scrcpy/scrcpy-1.21.ebuild: line 1: Invalid Copyright
