### PR TITLE
sys-kernel/xanmod-hybrid: fix RDEPEND

### DIFF
--- a/sys-kernel/xanmod-hybrid/xanmod-hybrid-5.15.13.ebuild
+++ b/sys-kernel/xanmod-hybrid/xanmod-hybrid-5.15.13.ebuild
@@ -30,8 +30,8 @@ REQUIRED_USE="^^ ( xanmod cacule )"
 # If you have been enable src_prepare-overlay
 # please unmerge sys-kernel/xanmod-sources
 RDEPEND="
-	!sys-kernel/xanmod-sources
-	!sys-kernel/xanmod-rt
+	!sys-kernel/xanmod-sources:${PV}
+	!sys-kernel/xanmod-rt:${PV}
 "
 DEPEND="app-arch/cpio"
 

--- a/sys-kernel/xanmod-hybrid/xanmod-hybrid-5.15.15.ebuild
+++ b/sys-kernel/xanmod-hybrid/xanmod-hybrid-5.15.15.ebuild
@@ -30,8 +30,8 @@ REQUIRED_USE="^^ ( xanmod cacule )"
 # If you have been enable src_prepare-overlay
 # please unmerge sys-kernel/xanmod-sources
 RDEPEND="
-	!sys-kernel/xanmod-sources
-	!sys-kernel/xanmod-rt
+	!sys-kernel/xanmod-sources:${PV}
+	!sys-kernel/xanmod-rt:${PV}
 "
 DEPEND="app-arch/cpio"
 


### PR DESCRIPTION
It should only block other xanmod varieties with the same slot.