### PR TITLE
app-i18n/mozc: consistent PYTHON_COMPAT style

### DIFF
--- a/app-i18n/mozc/mozc-9999.ebuild
+++ b/app-i18n/mozc/mozc-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 2010-2020 Gentoo Authors
+# Copyright 2010-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
-PYTHON_COMPAT=(python{3_7,3_8,3_9})
+PYTHON_COMPAT=( python3_{8..9} )
 
 inherit elisp-common multiprocessing python-any-r1 toolchain-funcs desktop xdg
 


### PR DESCRIPTION
[上游小更了一下](https://github.com/gentoo-mirror/gentoo/commit/7a55b8993e05e8701b1913ef5040318f7533b081#diff-618fde30060828f2aaa87bfa251fd86c2e24d1783d4bd0745661875a02e3f83e)，只是规范下写法，我这里跟进只是方便以后更新时对比了……（虽然不知道有没有接受的价值