### PR TITLE
app-i18n/fcitx5-kkc: clean DEPEND by qa-vdb

### DIFF
--- a/app-i18n/fcitx5-kkc/fcitx5-kkc-5.0.7.ebuild
+++ b/app-i18n/fcitx5-kkc/fcitx5-kkc-5.0.7.ebuild
@@ -20,9 +20,6 @@ DEPEND="
 	kde-frameworks/extra-cmake-modules
 	qt? (
 		app-i18n/fcitx5-qt
-		dev-qt/qtcore
-		dev-qt/qtgui
-		dev-qt/qtwidgets
 	)
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Signed-off-by: liuyujielol <2073201758GD@gmail.com>

> dev-qt/qtcore
> dev-qt/qtgui
> dev-qt/qtwidgets

这三个都是app-i18n/fcitx5-qt的依赖，应该可以去掉