### PR TITLE
hotfix for xanmod-kernel and dist-kernel::gentoo-zh

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,3 +1,7 @@
+# Yachen Wang <oripoin@outlook.com> 
+# mask for keywords mismatch of main tree
+virtual/dist-kernel
+
 # microcai
 # mask for testing
 =dev-libs/boost-1.54.0

--- a/sys-kernel/xanmod-kernel/xanmod-kernel-5.10.101.ebuild
+++ b/sys-kernel/xanmod-kernel/xanmod-kernel-5.10.101.ebuild
@@ -19,7 +19,7 @@ SRC_URI+=" https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.x
 S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
-KEYWORDS="amd64"
+KEYWORDS="~amd64"
 IUSE="cjk"
 SLOT="lts"
 
@@ -65,14 +65,12 @@ src_prepare() {
 		;;
 	esac
 
-	local myversion="-xanmod${XV}-lts"
+	local myversion="-xanmod${XV}"
 	echo "CONFIG_LOCALVERSION=\"${myversion}\"" >"${T}"/version.config || die
-	echo "CONFIG_DEFAULT_HOSTNAME=\"xanmod-lts\"" >"${T}"/hostname.config || die
 	echo "CONFIG_MODPROBE_PATH=\"/sbin/modprobe\"" >"${T}"/modprobe.config || die
 
 	local merge_configs=(
 		"${T}"/version.config
-		"${T}"/hostname.config
 		"${T}"/modprobe.config
 	)
 

--- a/sys-kernel/xanmod-kernel/xanmod-kernel-5.15.24.ebuild
+++ b/sys-kernel/xanmod-kernel/xanmod-kernel-5.15.24.ebuild
@@ -19,7 +19,7 @@ SRC_URI+=" https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.x
 S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
-KEYWORDS="amd64"
+KEYWORDS="~amd64"
 IUSE="cjk clang"
 SLOT="stable"
 
@@ -89,14 +89,12 @@ src_prepare() {
 		;;
 	esac
 
-	local myversion="-xanmod${XV}-lts"
+	local myversion="-xanmod${XV}"
 	echo "CONFIG_LOCALVERSION=\"${myversion}\"" >"${T}"/version.config || die
-	echo "CONFIG_DEFAULT_HOSTNAME=\"xanmod-lts\"" >"${T}"/hostname.config || die
 	echo "CONFIG_MODPROBE_PATH=\"/sbin/modprobe\"" >"${T}"/modprobe.config || die
 
 	local merge_configs=(
 		"${T}"/version.config
-		"${T}"/hostname.config
 		"${T}"/modprobe.config
 	)
 

--- a/sys-kernel/xanmod-kernel/xanmod-kernel-5.16.10.ebuild
+++ b/sys-kernel/xanmod-kernel/xanmod-kernel-5.16.10.ebuild
@@ -89,14 +89,12 @@ src_prepare() {
 		;;
 	esac
 
-	local myversion="-xanmod${XV}-lts"
+	local myversion="-xanmod${XV}"
 	echo "CONFIG_LOCALVERSION=\"${myversion}\"" >"${T}"/version.config || die
-	echo "CONFIG_DEFAULT_HOSTNAME=\"xanmod-lts\"" >"${T}"/hostname.config || die
 	echo "CONFIG_MODPROBE_PATH=\"/sbin/modprobe\"" >"${T}"/modprobe.config || die
 
 	local merge_configs=(
 		"${T}"/version.config
-		"${T}"/hostname.config
 		"${T}"/modprobe.config
 	)
 

--- a/virtual/dist-kernel/dist-kernel-5.10.101.ebuild
+++ b/virtual/dist-kernel/dist-kernel-5.10.101.ebuild
@@ -9,7 +9,7 @@ SRC_URI=""
 
 LICENSE=""
 SLOT="0/${PV}"
-KEYWORDS="amd64"
+KEYWORDS="~amd64"
 
 RDEPEND="
 	|| (

--- a/virtual/dist-kernel/dist-kernel-5.15.24.ebuild
+++ b/virtual/dist-kernel/dist-kernel-5.15.24.ebuild
@@ -9,7 +9,7 @@ SRC_URI=""
 
 LICENSE=""
 SLOT="0/${PV}"
-KEYWORDS="amd64"
+KEYWORDS="~amd64"
 
 RDEPEND="
 	|| (


### PR DESCRIPTION
修了一下昨天群里的问题
默认mask掉了dist-kernel