### PR TITLE
media-sound/termusic: fix src_install

### DIFF
--- a/media-sound/termusic/termusic-0.6.11.ebuild
+++ b/media-sound/termusic/termusic-0.6.11.ebuild
@@ -364,7 +364,12 @@ src_configure() {
 }
 
 src_install() {
-	default
+	# Calling *default* here portage will invoke *make install*
+	# which install binary into "${HOME}/.local/share/cargo/bin"
+	# Instead *cargo_src_install* should be called
+	# to properly install binary into "${ED}/usr/bin"
+	# pr 1906
+	cargo_src_install
 
 	local DOCS=(
 		CHANGELOG.md README.md


### PR DESCRIPTION
如果在src_install里面掉用default，二进制会被安装到~/.local/share/cargo/bin/
调用cargo_src_install才能正确安装到"${ED}/usr/bin"

原因是这个包里面有makefile，makefile默认的安装目录是用户的家目录....

@liangyongxiang 