### PR TITLE
net-proxy/clash: add GOAMD64 use flag

### DIFF
--- a/net-proxy/clash/metadata.xml
+++ b/net-proxy/clash/metadata.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<use>
+		<flag name="goamd64">detect golang arch level on amd64 cpus by CPU_FLAGS_X86</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">Dreamacro/clash</remote-id>
 	</upstream>


### PR DESCRIPTION
go 1.18 更新了编译时指定对于amd64 CPU的指令集支持[1]
clash的上游也加入了单独的amd64-v3 的release[2]

1. https://github.com/golang/go/wiki/MinimumRequirements#amd64
2. https://github.com/Dreamacro/clash/commit/02333a859a57ddb528eb469f734ebc2669911ee9

Signed-off-by: liuyujielol <2073201758GD@gmail.com>