### PR TITLE
fix: duplicate issues created by nvchecker action

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -9,6 +9,10 @@ on:
     # UTC 09:00 -> CST (China) 17:00, see https://datetime360.com/cn/utc-cst-china-time/
     - cron: '0 09 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nvchecker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Issues #2002 and #2003 are repeatedly created by nvchecker actions triggered
by two pushes in a short period of time, so `cancel-in-progress` should be used.

And also closes: #2003 when this pr merged.

Signed-off-by: peeweep <peeweep@0x0.ee>