### PR TITLE
app-office/wps-office: Fix icu>=71.1

### DIFF
--- a/app-office/wps-office/wps-office-11.1.0.10976.ebuild
+++ b/app-office/wps-office/wps-office-11.1.0.10976.ebuild
@@ -82,6 +82,7 @@ src_install() {
 
 	insinto /opt/kingsoft/wps-office
 	use systemd || { rm "${S}"/opt/kingsoft/wps-office/office6/libdbus-1.so* || die ; }
+	rm "${S}"/opt/kingsoft/wps-office/office6/libstdc++.so* || die
 	doins -r "${S}"/opt/kingsoft/wps-office/{office6,templates}
 
 	fperms 0755 /opt/kingsoft/wps-office/office6/{wps,wpp,et,wpspdf,wpsoffice,promecefpluginhost,transerr,ksolaunch,wpscloudsvr}


### PR DESCRIPTION
@microcai 蔡博士说icu升级之后会有这问题，我没开~也没测试，而且Arch的icu也是71就没事，我也不知道用不用得着……反正删了这玩意之后照样能用，就先改了罢