### PR TITLE
x11-themes/fcitx5-breeze: revision: use imagemagick instead of inkscape, change install_prefix

### DIFF
--- a/x11-themes/fcitx5-breeze/fcitx5-breeze-2.0.0-r1.ebuild
+++ b/x11-themes/fcitx5-breeze/fcitx5-breeze-2.0.0-r1.ebuild
@@ -12,15 +12,20 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 DEPEND="
-	media-gfx/inkscape"
+	media-gfx/imagemagick[png,svg]"
 RDEPEND="
 	app-i18n/fcitx5"
 BDEPEND=""
+
+src_prepare() {
+	sed "s,convert -o \"..\/build\/\$outfile\",convert,g" -i build.sh || die
+	eapply_user
+}
 
 src_compile() {
 	./build.sh
 }
 
 src_install() {
-	./install.sh "${D}/usr/local"
+	./install.sh "${D}/usr"
 }


### PR DESCRIPTION
安装路径一开始是上游这么写的，我是显式地写了出来，现在改成`/usr`
Signed-off-by: Yachen Wang <OriPoin@outlook.com>