### PR TITLE
media-gfx/zw3d: fix install path to solve maintenance issues

### DIFF
--- a/media-gfx/zw3d/zw3d-2022.26.00-r1.ebuild
+++ b/media-gfx/zw3d/zw3d-2022.26.00-r1.ebuild
@@ -53,18 +53,17 @@ S=${WORKDIR}
 QA_PREBUILT="*"
 
 src_install() {
-	# Move ${MY_PGK_NAME} out from /opt/apps
+	# Install scalable icons
 	mkdir -p "${S}"/usr/share/icons/hicolor/scalable/apps || die
-	mv "${S}"/opt/apps/${MY_PGK_NAME} "${S}"/opt/${MY_PGK_NAME} || die
-	mv "${S}"/opt/${MY_PGK_NAME}/entries/icons/hicolor/scalable/apps/*.svg "${S}"/usr/share/icons/hicolor/scalable/apps || die
+	mv "${S}"/opt/apps/${MY_PGK_NAME}/entries/icons/hicolor/scalable/apps/*.svg "${S}"/usr/share/icons/hicolor/scalable/apps || die
 
 	# Set RPATH for preserve-libs handling
-	pushd "${S}"/opt/${MY_PGK_NAME}/files || die
+	pushd "${S}"/opt/apps/${MY_PGK_NAME}/files || die
 	local x
 	for x in $(find) ; do
 		# Use \x7fELF header to separate ELF executables and libraries
 		[[ -f ${x} && $(od -t x1 -N 4 "${x}") == *"7f 45 4c 46"* ]] || continue
-		local RPATH_ROOT="/opt/${MY_PGK_NAME}/files"
+		local RPATH_ROOT="/opt/apps/${MY_PGK_NAME}/files"
 		local RPATH_S="${RPATH_ROOT}/:${RPATH_ROOT}/lib/:${RPATH_ROOT}/lib/xlator/:${RPATH_ROOT}/lib/xlator/InterOp/:${RPATH_ROOT}/libqt/:${RPATH_ROOT}/libqt/plugins/designer/:${RPATH_ROOT}/lib3rd/"
 		patchelf --set-rpath "${RPATH_S}" "${x}" || \
 			die "patchelf failed on ${x}"
@@ -81,29 +80,27 @@ src_install() {
 	# Add zw3d command
 	mkdir -p "${S}"/usr/bin/ || die
 
-	cat >> "${S}"/opt/${MY_PGK_NAME}/zw3d <<- EOF || die
+	cat >> "${S}"/opt/apps/${MY_PGK_NAME}/zw3d <<- EOF || die
 #!/bin/sh
-sh /opt/${MY_PGK_NAME}/files/zw3drun.sh \$*
+sh /opt/apps/${MY_PGK_NAME}/files/zw3drun.sh \$*
 	EOF
 
-	ln -s /opt/${MY_PGK_NAME}/zw3d "${S}"/usr/bin/zw3d || die
-
-	sed -i 's|/opt/apps/|/opt/|g' "${S}/opt/${MY_PGK_NAME}/files/zw3drun.sh" || die
+	ln -s /opt/apps/${MY_PGK_NAME}/zw3d "${S}"/usr/bin/zw3d || die
 
 	# Use system libraries
-	rm -rf "${S}"/opt/${MY_PGK_NAME}/files/lib3rd/libMagickCore* || die
-	rm -rf "${S}"/opt/${MY_PGK_NAME}/files/lib3rd/libjpeg* || die
+	rm -rf "${S}"/opt/apps/${MY_PGK_NAME}/files/lib3rd/libMagickCore* || die
+	rm -rf "${S}"/opt/apps/${MY_PGK_NAME}/files/lib3rd/libjpeg* || die
 
 	# Install package and fix permissions
-	insinto /opt
-	doins -r opt/${MY_PGK_NAME}
+	insinto /opt/apps
+	doins -r opt/apps/${MY_PGK_NAME}
 	insinto /usr
 	doins -r usr/*
 
-	fperms 0755 /opt/${MY_PGK_NAME}/zw3d
+	fperms 0755 /opt/apps/${MY_PGK_NAME}/zw3d
 
 	pushd "${S}" || die
-	for x in $(find "opt/${MY_PGK_NAME}") ; do
+	for x in $(find "opt/apps/${MY_PGK_NAME}") ; do
 		# Fix shell script permissions
 		[[ "${x: -3}" == ".sh" ]] && fperms 0755 "/${x}"
 		# Use \x7fELF header to separate ELF executables and libraries


### PR DESCRIPTION
Use the upstream path to facilitate later upgrades and debugging.