### PR TITLE
app-emulation/deepin-wine6-stable: fix preserved-rebuild problem

### DIFF
--- a/.github/workflows/pkgcheck-checks-on-pr.yml
+++ b/.github/workflows/pkgcheck-checks-on-pr.yml
@@ -1,5 +1,6 @@
 name: pkgcheck
 on:
+  workflow_dispatch:
   pull_request_target:
     branches:
       - master
@@ -7,6 +8,10 @@ on:
       - '.github/**'
       - 'metadata/**'
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   check-changed-ebuilds:
@@ -63,6 +68,10 @@ jobs:
         run: |
           set -e
           mv ${GITHUB_WORKSPACE}/gentoo-zh /var/db/repos/
+          cat /var/db/repos/gentoo-zh/profiles/arch/amd64/no-multilib/package.mask >> /var/db/repos/gentoo/profiles/arch/amd64/no-multilib/package.mask
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          pushd /var/db/repos/gentoo && git commit -am"profiles/*: append mask form ::gentoo-zh" && popd
           mkdir -p /etc/portage/repos.conf
           echo "[gentoo]
           location = /var/db/repos/gentoo

--- a/app-emulation/deepin-wine6-stable/deepin-wine6-stable-6.0.0.19-r1.ebuild
+++ b/app-emulation/deepin-wine6-stable/deepin-wine6-stable-6.0.0.19-r1.ebuild
@@ -52,6 +52,7 @@ RDEPEND="${DEPEND}
 "
 
 S=${WORKDIR}
+QA_PREBUILT="*"
 
 src_install() {
 	insinto /

--- a/app-emulation/deepin-wine6-stable/metadata.xml
+++ b/app-emulation/deepin-wine6-stable/metadata.xml
@@ -6,6 +6,9 @@
 		<email>iamoatiz@gmail.com</email>
 	</maintainer>
 	<longdescription>
-		Deepin wine6 stable.
+	Deepin-wine is a Wine-based compatibility layer developed by Wuhan Deepin
+	Technology Co., Ltd., which is attached to deepin Linux.
+	Deepin-wine's applications work almost out of the box,
+	with fewer bugs(compared to wine).
 	</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
Prevent unnecessary preserved-rebuild warnings