### PR TITLE
x11-themes/nordzy-icon: fix the path(v1.5) of installation

### DIFF
--- a/x11-themes/nordzy-icon/nordzy-icon-1.5.ebuild
+++ b/x11-themes/nordzy-icon/nordzy-icon-1.5.ebuild
@@ -21,6 +21,6 @@ src_configure() { :; }
 src_compile() { :; }
 
 src_install() {
-	insinto /usr/share/icons
-	doins -r ./Nordzy
+	insinto /usr/share/icons/Nordzy
+	doins -r ./
 }


### PR DESCRIPTION
Signed-off-by: Jaus_Hwang <jaus_hwang@88.com>