### PR TITLE
app-i18n/mozc: sync live

### DIFF
--- a/app-i18n/mozc/mozc-9999.ebuild
+++ b/app-i18n/mozc/mozc-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit elisp-common multiprocessing python-any-r1 toolchain-funcs desktop xdg
 


### PR DESCRIPTION
纯粹是为了跟进[main tree更新](https://github.com/gentoo-mirror/gentoo/commit/b72993b4129d7cd1840b5940ea96957476f00cb2)的，并没有啥实际意义，毕竟9999目前根本没法用……