### PR TITLE
app-i18n/fcitx-configtool: disable kcm by default, close #2312

### DIFF
--- a/app-i18n/fcitx-configtool/fcitx-configtool-5.0.14.ebuild
+++ b/app-i18n/fcitx-configtool/fcitx-configtool-5.0.14.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://fcitx-im.org/ https://github.com/fcitx/fcitx5-configtool"
 
 LICENSE="GPL-2+"
 SLOT="5"
-IUSE="+kcm +config-qt test"
+IUSE="kcm +config-qt test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="app-i18n/fcitx:5
@@ -44,7 +44,7 @@ RDEPEND="app-i18n/fcitx:5
 	config-qt? (
 		kde-frameworks/kitemviews:5
 	)
-	!${CATEGORY}/${PN}:4[-minimal(-)]"
+"
 
 DEPEND="${RDEPEND}
 	kde-frameworks/extra-cmake-modules:5

--- a/app-i18n/fcitx-configtool/fcitx-configtool-9999.ebuild
+++ b/app-i18n/fcitx-configtool/fcitx-configtool-9999.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://fcitx-im.org/ https://github.com/fcitx/fcitx5-configtool"
 
 LICENSE="GPL-2+"
 SLOT="5"
-IUSE="+kcm +config-qt test"
+IUSE="kcm +config-qt test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="app-i18n/fcitx:5
@@ -44,7 +44,7 @@ RDEPEND="app-i18n/fcitx:5
 	config-qt? (
 		kde-frameworks/kitemviews:5
 	)
-	!${CATEGORY}/${PN}:4[-minimal(-)]"
+"
 
 DEPEND="${RDEPEND}
 	kde-frameworks/extra-cmake-modules:5


### PR DESCRIPTION
#2312 经liang菊苣指导原来是kcm 开启导致的，是早期版本在非KDE环境下有 #512 的问题所以默认被开了。现在三年过去fcitx5应该已经解决问题，liang菊苣就推荐我pr一下把默认去了我也就pr了，顺便夹带私货去掉了和:4的block（

不过在群里调查后发现非KDE的菊苣们自己都知道-kcm，只有我完全不懂一直默认没改，出问题还一筹莫展，我果然从来都是最菜的😭