### PR TITLE
app-emulation/deepin-wine-helper: add python depend

### DIFF
--- a/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.27-r1.ebuild
+++ b/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.27-r1.ebuild
@@ -1,9 +1,10 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit unpacker
+PYTHON_COMPAT=( python3_{8..11} )
+inherit python-r1 unpacker
 
 DESCRIPTION="Deepin Wine Helper"
 HOMEPAGE="https://www.deepin.org"
@@ -15,10 +16,14 @@ LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+RESTRICT="test"
 
-DEPEND=""
-RDEPEND="${DEPEND}
-	app-emulation/deepin-wine-plugin[virtual-pkg]"
+RDEPEND="
+	${PYTHON_DEPS}
+	app-emulation/deepin-wine-plugin[virtual-pkg]
+"
+DEPEND="${RDEPEND}"
 
 S=${WORKDIR}
 
@@ -26,6 +31,8 @@ QA_PREBUILT="opt/deepinwine/*"
 QA_FLAGS_IGNORED="opt/deepinwine/*"
 
 src_install() {
+	python_fix_shebang -f "opt/deepinwine/tools/add_hotkeys"
+	python_fix_shebang -f "opt/deepinwine/tools/get_tray_window"
 	insinto /
 	doins -r opt
 

--- a/app-emulation/deepin-wine-helper/metadata.xml
+++ b/app-emulation/deepin-wine-helper/metadata.xml
@@ -5,7 +5,12 @@
 		<name>lyraile</name>
 		<email>iamoatiz@gmail.com</email>
 	</maintainer>
-	<longdescription>
-		Deepin Wine helper.
+	<longdescription lang="en">
+		helper script from deepin-wine. Used to run deepin-wine related programs
+		and provide common operations for deepin wine programs.
+	</longdescription>
+	<longdescription lang="zh">
+		来自于deepin-wine的辅助脚本。
+		用来运行deepin-wine相关的程序，提供对deepin wine程序的公共操作。
 	</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
Some scripts in this package depend on python, so add python as depend