### PR TITLE
app-emulation/deepin-wine-helper: use python-single-r1 instead

### DIFF
--- a/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.27-r1.ebuild
+++ b/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.27-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..11} )
-inherit python-r1 unpacker
+inherit python-single-r1 unpacker
 
 DESCRIPTION="Deepin Wine Helper"
 HOMEPAGE="https://www.deepin.org"


### PR DESCRIPTION
Fix install error (missing EPYTHON when fix shebang) 
