### PR TITLE
app-i18n/fcitx: add missing deps(maybe incomplete)

### DIFF
--- a/app-i18n/fcitx/fcitx-5.0.19-r1.ebuild
+++ b/app-i18n/fcitx/fcitx-5.0.19-r1.ebuild
@@ -21,7 +21,7 @@ SRC_URI+=" https://download.fcitx-im.org/data/en_dict-20121020.tar.gz -> fcitx-d
 
 LICENSE="BSD-1 GPL-2+ LGPL-2+ MIT"
 SLOT="5"
-IUSE="+enchant test coverage doc presage systemd wayland +X"
+IUSE="+enchant +emoji test coverage doc presage systemd wayland +X"
 REQUIRED_USE="
 	|| ( wayland X )
 	coverage? ( test )
@@ -29,14 +29,28 @@ REQUIRED_USE="
 
 RESTRICT="!test? ( test )"
 
-RDEPEND="dev-libs/glib:2
+RDEPEND="
+	emoji? ( app-i18n/unicode-cldr )
+
+	test? (
+		coverage? (
+			dev-util/lcov
+		)
+	)
+
+	doc? (
+		app-doc/doxygen
+	)
+
+	dev-libs/expat
+	dev-libs/glib:2
 	sys-apps/dbus
 	dev-libs/json-c
 	dev-libs/libfmt
 	sys-apps/util-linux
 	virtual/libiconv
 	virtual/libintl
-	x11-libs/libxkbcommon[X?]
+	x11-libs/libxkbcommon[X?,wayland?]
 	wayland? (
 		dev-libs/wayland
 		dev-libs/wayland-protocols
@@ -48,16 +62,20 @@ RDEPEND="dev-libs/glib:2
 		x11-libs/libXrender
 		x11-libs/libXinerama
 		x11-libs/libxkbfile
+		x11-libs/libxcb
+		x11-libs/xcb-util
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-wm
 		~x11-libs/xcb-imdkit-1.0.3
 	)
 	x11-misc/xkeyboard-config
 	x11-libs/cairo[X?]
-	x11-libs/pango
+	x11-libs/pango[X?]
 	media-libs/fontconfig
-	enchant? ( app-text/enchant:= )
+	enchant? ( app-text/enchant:2 )
 	systemd? ( sys-apps/systemd )
 	app-text/iso-codes
-	app-i18n/unicode-cldr
+
 	dev-libs/libxml2
 	dev-libs/libevent
 	x11-libs/gdk-pixbuf:2
@@ -66,6 +84,15 @@ DEPEND="${RDEPEND}
 	kde-frameworks/extra-cmake-modules:5
 	virtual/pkgconfig
 "
+
+src_unpack() {
+	if [[ "${PV}" == 9999 ]]; then
+		git-r3_src_unpack
+	else
+		# avoid unpacking fcitx-data-en_dict-20121020.tar.gz
+		unpack "${P}.tar.gz"
+	fi
+}
 
 src_prepare() {
 	ln -s "${DISTDIR}/fcitx-data-en_dict-20121020.tar.gz" src/modules/spell/en_dict-20121020.tar.gz || die
@@ -85,6 +112,7 @@ src_configure() {
 		-DENABLE_TEST=$(usex test)
 		-DENABLE_COVERAGE=$(usex coverage)
 		-DENABLE_ENCHANT=$(usex enchant)
+		-DENABLE_EMOJI=$(usex emoji)
 		-DENABLE_PRESAGE=$(usex presage)
 		-DENABLE_WAYLAND=$(usex wayland)
 		-DENABLE_X11=$(usex X)

--- a/app-i18n/fcitx/fcitx-9999.ebuild
+++ b/app-i18n/fcitx/fcitx-9999.ebuild
@@ -21,7 +21,7 @@ SRC_URI+=" https://download.fcitx-im.org/data/en_dict-20121020.tar.gz -> fcitx-d
 
 LICENSE="BSD-1 GPL-2+ LGPL-2+ MIT"
 SLOT="5"
-IUSE="+enchant test coverage doc presage systemd wayland +X"
+IUSE="+enchant +emoji test coverage doc presage systemd wayland +X"
 REQUIRED_USE="
 	|| ( wayland X )
 	coverage? ( test )
@@ -29,14 +29,28 @@ REQUIRED_USE="
 
 RESTRICT="!test? ( test )"
 
-RDEPEND="dev-libs/glib:2
+RDEPEND="
+	emoji? ( app-i18n/unicode-cldr )
+
+	test? (
+		coverage? (
+			dev-util/lcov
+		)
+	)
+
+	doc? (
+		app-doc/doxygen
+	)
+
+	dev-libs/expat
+	dev-libs/glib:2
 	sys-apps/dbus
 	dev-libs/json-c
 	dev-libs/libfmt
 	sys-apps/util-linux
 	virtual/libiconv
 	virtual/libintl
-	x11-libs/libxkbcommon[X?]
+	x11-libs/libxkbcommon[X?,wayland?]
 	wayland? (
 		dev-libs/wayland
 		dev-libs/wayland-protocols
@@ -48,16 +62,20 @@ RDEPEND="dev-libs/glib:2
 		x11-libs/libXrender
 		x11-libs/libXinerama
 		x11-libs/libxkbfile
+		x11-libs/libxcb
+		x11-libs/xcb-util
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-wm
 		~x11-libs/xcb-imdkit-1.0.3
 	)
 	x11-misc/xkeyboard-config
 	x11-libs/cairo[X?]
-	x11-libs/pango
+	x11-libs/pango[X?]
 	media-libs/fontconfig
-	enchant? ( app-text/enchant:= )
+	enchant? ( app-text/enchant:2 )
 	systemd? ( sys-apps/systemd )
 	app-text/iso-codes
-	app-i18n/unicode-cldr
+
 	dev-libs/libxml2
 	dev-libs/libevent
 	x11-libs/gdk-pixbuf:2
@@ -67,8 +85,16 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
+src_unpack() {
+	if [[ "${PV}" == 9999 ]]; then
+		git-r3_src_unpack
+	else
+		# avoid unpacking fcitx-data-en_dict-20121020.tar.gz
+		unpack "${P}.tar.gz"
+	fi
+}
+
 src_prepare() {
-	pwd
 	ln -s "${DISTDIR}/fcitx-data-en_dict-20121020.tar.gz" src/modules/spell/dict/en_dict-20121020.tar.gz || die
 
 	cmake_src_prepare
@@ -81,6 +107,7 @@ src_configure() {
 		-DENABLE_TEST=$(usex test)
 		-DENABLE_COVERAGE=$(usex coverage)
 		-DENABLE_ENCHANT=$(usex enchant)
+		-DENABLE_EMOJI=$(usex emoji)
 		-DENABLE_PRESAGE=$(usex presage)
 		-DENABLE_WAYLAND=$(usex wayland)
 		-DENABLE_X11=$(usex X)

--- a/app-i18n/fcitx/metadata.xml
+++ b/app-i18n/fcitx/metadata.xml
@@ -19,8 +19,9 @@
 		<flag name="pango">Enable support for <pkg>x11-libs/pango</pkg></flag>
 		<flag name="table">Install table input methods for Simplified Chinese</flag>
 		<flag name="xkb">Enable support for XKB (required for fcitx-xkb, fcitx-xkbdbus, part of fcitx-keyboard)</flag>
-		<flag name='coverage'>Build the project with gcov support (Need ENABLE_TEST=On)</flag>
-		<flag name='presage'>Enable presage for word predication (not stable)</flag>
+		<flag name="coverage">Build the project with gcov support (Need ENABLE_TEST=On)</flag>
+		<flag name="presage">Enable presage for word predication (not stable)</flag>
+		<flag name="emoji">Enable emoji loading for CLDR</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">fcitx/fcitx</remote-id>


### PR DESCRIPTION
add use flag 'emoji'
'app-text/enchant:=' -> 'app-text/enchant:2'[1]

add deps for 'coverage'
command execution required[2]:
```
sys-devel/gcc -> gcov gcov-tool
dev-util/lcov -> lcov genhtml
```

add deps for 'doc'[3]
+command execution required:
```
app-doc/doxygen -> doxygen
```

add missing deps(maybe incomplete):
```
dev-libs/expat[4]
x11-libs/libxcb
x11-libs/xcb-util
x11-libs/xcb-util-keysyms
x11-libs/xcb-util-wm[5]
```

[1].https://github.com/fcitx/fcitx5/blob/da7c3ceda592558728108603c1d936f4230c8f96/CMakeLists.txt#L166
[2].https://github.com/fcitx/fcitx5/blob/da7c3ceda592558728108603c1d936f4230c8f96/CMakeLists.txt#L224
[3].https://github.com/fcitx/fcitx5/blob/da7c3ceda592558728108603c1d936f4230c8f96/CMakeLists.txt#L231
[4].https://github.com/fcitx/fcitx5/blob/da7c3ceda592558728108603c1d936f4230c8f96/CMakeLists.txt#L134
[5].https://github.com/fcitx/fcitx5/blob/da7c3ceda592558728108603c1d936f4230c8f96/CMakeLists.txt#L127

Signed-off-by: liuyujielol <2073201758GD@gmail.com>