### PR TITLE
app-i18n/fcitx-chinese-addons: potential missing deps

### DIFF
--- a/app-i18n/fcitx-chinese-addons/fcitx-chinese-addons-5.0.15-r1.ebuild
+++ b/app-i18n/fcitx-chinese-addons/fcitx-chinese-addons-5.0.15-r1.ebuild
@@ -25,20 +25,33 @@ HOMEPAGE="https://github.com/fcitx/fcitx5-chinese-addons"
 
 LICENSE="BSD-1 GPL-2+ LGPL-2+ MIT"
 SLOT="5"
-IUSE="browser +gui lua +opencc test"
-REQUIRED_USE=""
+IUSE="browser +cloudpinyin coverage +gui lua +opencc test"
+REQUIRED_USE="
+	coverage? ( test )
+	browser? ( gui )
+"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	app-i18n/fcitx:5
-	app-i18n/libime
+	>=app-i18n/fcitx-5.0.11:5
+	>=app-i18n/libime-1.0.14:5
+
+	>=dev-libs/boost-1.61:=
+	dev-libs/libfmt
+
+	cloudpinyin? ( net-misc/curl )
 	opencc? ( app-i18n/opencc:= )
 	gui? (
+		dev-qt/qtgui:5
 		dev-qt/qtcore:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtdbus:5
+		dev-qt/qtconcurrent:5
 		app-i18n/fcitx-qt:5[qt5,-onlyplugin]
 		browser? ( dev-qt/qtwebengine:5 )
-		lua? ( app-i18n/fcitx-lua:5 )
 	)
+	lua? ( app-i18n/fcitx-lua:5 )
+	test? ( dev-util/lcov )
 "
 DEPEND="${RDEPEND}
 	kde-frameworks/extra-cmake-modules:5
@@ -57,6 +70,9 @@ src_configure() {
 		-DENABLE_GUI=$(usex gui)
 		-DENABLE_OPENCC=$(usex opencc)
 		-DENABLE_BROWSER=$(usex browser)
+		-DENABLE_CLOUDPINYIN=$(usex cloudpinyin)
+		-DENABLE_TEST=$(usex test)
+		-DENABLE_COVERAGE=$(usex coverage)
 		-DUSE_WEBKIT=no
 	)
 	cmake_src_configure

--- a/app-i18n/fcitx-chinese-addons/fcitx-chinese-addons-9999.ebuild
+++ b/app-i18n/fcitx-chinese-addons/fcitx-chinese-addons-9999.ebuild
@@ -25,20 +25,33 @@ HOMEPAGE="https://github.com/fcitx/fcitx5-chinese-addons"
 
 LICENSE="BSD-1 GPL-2+ LGPL-2+ MIT"
 SLOT="5"
-IUSE="browser +gui lua +opencc test"
-REQUIRED_USE=""
+IUSE="browser +cloudpinyin coverage +gui lua +opencc test"
+REQUIRED_USE="
+	coverage? ( test )
+	browser? ( gui )
+"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	app-i18n/fcitx:5
-	app-i18n/libime
+	>=app-i18n/fcitx-5.0.11:5
+	>=app-i18n/libime-1.0.14:5
+
+	>=dev-libs/boost-1.61:=
+	dev-libs/libfmt
+
+	cloudpinyin? ( net-misc/curl )
 	opencc? ( app-i18n/opencc:= )
 	gui? (
+		dev-qt/qtgui:5
 		dev-qt/qtcore:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtdbus:5
+		dev-qt/qtconcurrent:5
 		app-i18n/fcitx-qt:5[qt5,-onlyplugin]
 		browser? ( dev-qt/qtwebengine:5 )
-		lua? ( app-i18n/fcitx-lua:5 )
 	)
+	lua? ( app-i18n/fcitx-lua:5 )
+	test? ( dev-util/lcov )
 "
 DEPEND="${RDEPEND}
 	kde-frameworks/extra-cmake-modules:5
@@ -57,6 +70,9 @@ src_configure() {
 		-DENABLE_GUI=$(usex gui)
 		-DENABLE_OPENCC=$(usex opencc)
 		-DENABLE_BROWSER=$(usex browser)
+		-DENABLE_CLOUDPINYIN=$(usex cloudpinyin)
+		-DENABLE_TEST=$(usex test)
+		-DENABLE_COVERAGE=$(usex coverage)
 		-DUSE_WEBKIT=no
 	)
 	cmake_src_configure

--- a/app-i18n/fcitx-chinese-addons/metadata.xml
+++ b/app-i18n/fcitx-chinese-addons/metadata.xml
@@ -8,5 +8,7 @@
 		<flag name="opencc">Enable support for conversion between Traditional and Simplified Chinese</flag>
 		<flag name="gui">Enable configure gui</flag>
 		<flag name="browser">Enable built-in browser using <pkg>dev-qt/qtwebengine</pkg></flag>
+		<flag name="cloudpinyin">Build cloud pinyin addon</flag>
+		<flag name="coverage">Build the project with gcov support (Need USE=test)</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
add USE flag 'cloudpinyin' 'coverage'

>\>=app-i18n/fcitx-5.0.11:5
>\>=app-i18n/libime-1.0.14:5
dev-libs/boost:=
dev-libs/libfmt
cloudpinyin? ( net-misc/curl )

move 'lua' out of 'gui' condition


<details>
  <summary>based on cmake_src_configure</summary>

```
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Pthread: /usr/include  
-- Found PkgConfig: /usr/bin/x86_64-pc-linux-gnu-pkg-config (found version "1.8.0") 
-- Found Gettext: /usr/bin/msgmerge (found version "0.21") 
-- Found OpenCC: /usr/lib64/libopencc.so (found version "1.1.4") 
-- Found Boost: /usr/lib64/cmake/Boost-1.80.0/BoostConfig.cmake (found suitable version "1.80.0", minimum required is "1.61") found components: iostreams 
-- Found Boost: /usr/lib64/cmake/Boost-1.80.0/BoostConfig.cmake (found suitable version "1.80.0", minimum required is "1.61")  
-- The following REQUIRED packages have been found:

 * ECM
 * Fcitx5ModuleNotifications
 * Fcitx5ModuleQuickPhrase
 * Fcitx5ModuleSpell
 * Fcitx5ModuleClipboard
 * Fcitx5ModuleTestFrontend
 * Fcitx5ModuleTestIM
 * Fcitx5Module
 * Pthread
 * Gettext
 * fmt
 * PkgConfig
 * OpenCC
 * Qt5Concurrent
 * Qt5
 * Fcitx5Qt5WidgetsAddons
 * Qt5Core (required version >= 5.1.0)
 * Qt5DBus (required version >= 5.1.0)
 * Fcitx5Qt5DBusAddons
 * boost_iostreams (required version == 1.80.0)
 * LibIMEPinyin (required version >= 1.0.14)
 * boost_headers (required version == 1.80.0)
 * Boost (required version >= 1.61)
 * LibIMETable (required version >= 1.0.12)

-- The following OPTIONAL packages have not been found:

 * Fcitx5ModuleLuaAddonLoader
```
</details>

Signed-off-by: liuyujielol <2073201758GD@gmail.com>