### PR TITLE
app-i18n/mozc/files: [QA] use git-format-patch style patches

### DIFF
--- a/app-i18n/mozc/files/mozc-2.26.4220-environmental_variables.patch
+++ b/app-i18n/mozc/files/mozc-2.26.4220-environmental_variables.patch
@@ -1,7 +1,7 @@
 https://github.com/google/mozc/issues/470
 
---- /src/base/system_util.cc
-+++ /src/base/system_util.cc
+--- a/src/base/system_util.cc
++++ b/src/base/system_util.cc
 @@ -226,6 +226,11 @@
  
  std::string UserProfileDirectoryImpl::GetUserProfileDirectory() const {

--- a/app-i18n/mozc/files/mozc-2.26.4220-server_path_check.patch
+++ b/app-i18n/mozc/files/mozc-2.26.4220-server_path_check.patch
@@ -1,7 +1,7 @@
 https://github.com/google/mozc/issues/471
 
---- /src/ipc/ipc_path_manager.cc
-+++ /src/ipc/ipc_path_manager.cc
+--- a/src/ipc/ipc_path_manager.cc
++++ b/src/ipc/ipc_path_manager.cc
 @@ -340,9 +340,21 @@
      return false;
    }

--- a/app-i18n/mozc/files/mozc-2.26.4220-system_abseil-cpp.patch
+++ b/app-i18n/mozc/files/mozc-2.26.4220-system_abseil-cpp.patch
@@ -1,7 +1,7 @@
 https://github.com/google/mozc/issues/490
 
---- /src/base/absl.gyp
-+++ /src/base/absl.gyp
+--- a/src/base/absl.gyp
++++ b/src/base/absl.gyp
 @@ -28,119 +28,209 @@
  # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  
@@ -301,8 +301,8 @@ https://github.com/google/mozc/issues/490
        ],
      },
    ],
---- /src/config/config_test.gyp
-+++ /src/config/config_test.gyp
+--- a/src/config/config_test.gyp
++++ b/src/config/config_test.gyp
 @@ -36,6 +36,7 @@
          'config_handler_test.cc',
        ],
@@ -319,8 +319,8 @@ https://github.com/google/mozc/issues/490
          '../testing/testing.gyp:gtest_main',
          'config.gyp:character_form_manager',
        ],
---- /src/gyp/common.gypi
-+++ /src/gyp/common.gypi
+--- a/src/gyp/common.gypi
++++ b/src/gyp/common.gypi
 @@ -194,7 +194,13 @@
      'include_dirs': [
        '<(abs_depth)',
@@ -336,8 +336,8 @@ https://github.com/google/mozc/issues/490
      ],
      'mac_framework_headers': [],
      'target_conditions': [
---- /src/gyp/common_win.gypi
-+++ /src/gyp/common_win.gypi
+--- a/src/gyp/common_win.gypi
++++ b/src/gyp/common_win.gypi
 @@ -307,10 +307,16 @@
      'include_dirs': [
        '<(abs_depth)',
@@ -356,8 +356,8 @@ https://github.com/google/mozc/issues/490
      'msvs_configuration_attributes': {
        'CharacterSet': '<(win_char_set_unicode)',
      },
---- /src/gyp/defines.gypi
-+++ /src/gyp/defines.gypi
+--- a/src/gyp/defines.gypi
++++ b/src/gyp/defines.gypi
 @@ -63,6 +63,10 @@
      # use_libibus represents if ibus library is used or not.
      # This option is only for Linux.
@@ -369,8 +369,8 @@ https://github.com/google/mozc/issues/490
    },
    'target_defaults': {
      'defines': [
---- /src/gyp/directories.gypi
-+++ /src/gyp/directories.gypi
+--- a/src/gyp/directories.gypi
++++ b/src/gyp/directories.gypi
 @@ -31,7 +31,12 @@
    'variables': {
      # Top directory of third party libraries.
@@ -385,8 +385,8 @@ https://github.com/google/mozc/issues/490
  
      # Top directory of additional third party libraries.
      'ext_third_party_dir%': '<(abs_depth)/third_party',
---- /src/session/session_test.gyp
-+++ /src/session/session_test.gyp
+--- a/src/session/session_test.gyp
++++ b/src/session/session_test.gyp
 @@ -221,6 +221,7 @@
          'internal/key_event_transformer_test.cc',
        ],
@@ -395,8 +395,8 @@ https://github.com/google/mozc/issues/490
          '../base/base.gyp:base',
          '../converter/converter_base.gyp:converter_mock',
          '../engine/engine.gyp:mock_converter_engine',
---- /src/storage/storage_test.gyp
-+++ /src/storage/storage_test.gyp
+--- a/src/storage/storage_test.gyp
++++ b/src/storage/storage_test.gyp
 @@ -41,6 +41,7 @@
          'tiny_storage_test.cc',
        ],

--- a/app-i18n/mozc/files/mozc-2.26.4220-system_gtest.patch
+++ b/app-i18n/mozc/files/mozc-2.26.4220-system_gtest.patch
@@ -1,7 +1,7 @@
 https://github.com/google/mozc/issues/490
 
---- /src/gyp/defines.gypi
-+++ /src/gyp/defines.gypi
+--- a/src/gyp/defines.gypi
++++ b/src/gyp/defines.gypi
 @@ -67,6 +67,10 @@
      # use_system_abseil_cpp represents if system version or bundled version
      # of abseil-cpp library is used.
@@ -13,8 +13,8 @@ https://github.com/google/mozc/issues/490
    },
    'target_defaults': {
      'defines': [
---- /src/testing/testing.gyp
-+++ /src/testing/testing.gyp
+--- a/src/testing/testing.gyp
++++ b/src/testing/testing.gyp
 @@ -59,54 +59,76 @@
    'targets': [
      {

--- a/app-i18n/mozc/files/mozc-2.26.4220-system_jsoncpp.patch
+++ b/app-i18n/mozc/files/mozc-2.26.4220-system_jsoncpp.patch
@@ -1,7 +1,7 @@
 https://github.com/google/mozc/issues/490
 
---- /src/gyp/defines.gypi
-+++ /src/gyp/defines.gypi
+--- a/src/gyp/defines.gypi
++++ b/src/gyp/defines.gypi
 @@ -71,6 +71,10 @@
      # use_system_gtest represents if system version or bundled version
      # of gtest library is used.
@@ -13,8 +13,8 @@ https://github.com/google/mozc/issues/490
    },
    'target_defaults': {
      'defines': [
---- /src/net/jsoncpp.gyp
-+++ /src/net/jsoncpp.gyp
+--- a/src/net/jsoncpp.gyp
++++ b/src/net/jsoncpp.gyp
 @@ -31,32 +31,60 @@
    'targets': [
      {
@@ -101,8 +101,8 @@ https://github.com/google/mozc/issues/490
      },
    ],
  }
---- /src/net/jsoncpp.h
-+++ /src/net/jsoncpp.h
+--- a/src/net/jsoncpp.h
++++ b/src/net/jsoncpp.h
 @@ -35,7 +35,11 @@
  // Mozc basically disables C++ exception.
  #define JSON_USE_EXCEPTION 0


### PR DESCRIPTION
仅为跟进 [main tree 更新](https://github.com/gentoo-mirror/gentoo/commit/2dde117d786ededb83e8c60ab7601976b55c897a)