### PR TITLE
app-office/wps-office:prevent @preserved-rebuild

### DIFF
--- a/app-office/wps-office/wps-office-11.1.0.11664.ebuild
+++ b/app-office/wps-office/wps-office-11.1.0.11664.ebuild
@@ -67,6 +67,7 @@ RDEPEND="
 	media-libs/libvorbis
 	dev-libs/libgpg-error
 	sys-apps/attr
+	dev-qt/qtlocation
 "
 DEPEND=""
 BDEPEND=""


### PR DESCRIPTION
没有装qtlocation时会导致每次更新软件都会报需要@preserved-rebuild，而且emerge @preserved-rebuild时一定会重新安装wps