### PR TITLE
net-im/tencent-qq: symlink -> ro-bind (split-usr)

### DIFF
--- a/net-im/tencent-qq/tencent-qq-2.0.1_beta1_p429.ebuild
+++ b/net-im/tencent-qq/tencent-qq-2.0.1_beta1_p429.ebuild
@@ -42,6 +42,7 @@ src_install() {
 	printf "#!/bin/bash\ncd /opt/QQ\n./qq \$@\n" > qq || die
 	if use bwrap ;then
 		if use split-usr ;then
+			sed -i 's!symlink!ro-bind!' "${FILESDIR}"/start.sh || die
 			sed -i 's!usr/!/!' "${FILESDIR}"/start.sh || die
 		fi
 		sed -i 's!./qq!/opt/QQ/start.sh!' qq || die


### PR DESCRIPTION
由于split-usr的情况下，/lib*不是软连接，因此需要使用ro-bind