### PR TITLE
media-gfx/zw3d: fix bug and depend <media-libs/tiff-4.5.0

### DIFF
--- a/media-gfx/zw3d/zw3d-2022.0.3.1-r1.ebuild
+++ b/media-gfx/zw3d/zw3d-2022.0.3.1-r1.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	media-libs/libglvnd
 	media-libs/libpng
 	media-libs/opencollada
-	<media-libs/tiff-4.5.0
+	media-libs/tiff-compat:4
 	net-libs/zeromq
 	sys-libs/zlib
 	x11-libs/cairo

--- a/media-gfx/zw3d/zw3d-2022.0.3.1-r1.ebuild
+++ b/media-gfx/zw3d/zw3d-2022.0.3.1-r1.ebuild
@@ -21,7 +21,6 @@ RDEPEND="
 	app-arch/xz-utils
 	app-text/djvu
 	dev-db/sqlite:3
-	dev-libs/atk
 	dev-libs/glib:2
 	dev-libs/libpcre
 	dev-libs/libxml2
@@ -36,7 +35,7 @@ RDEPEND="
 	media-libs/libglvnd
 	media-libs/libpng
 	media-libs/opencollada
-	media-libs/tiff
+	<media-libs/tiff-4.5.0
 	net-libs/zeromq
 	sys-libs/zlib
 	x11-libs/cairo


### PR DESCRIPTION
libtiff has been upgraded, causing a series of software not to work, so the version needs to be restricted.