### PR TITLE
net-proxy/v2rayA: fix openssl-legacy-option error

### DIFF
--- a/net-proxy/v2rayA/v2rayA-2.0.1.ebuild
+++ b/net-proxy/v2rayA/v2rayA-2.0.1.ebuild
@@ -53,8 +53,8 @@ src_unpack() {
 
 src_compile() {
 	cd "${S}/gui" || die
-	#Fix node build error: https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
-	export NODE_OPTIONS=--openssl-legacy-provider
+	## Fix node build error: https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
+	# export NODE_OPTIONS=--openssl-legacy-provider
 	OUTPUT_DIR="${S}/service/server/router/web" yarn build || die "yarn build failed"
 
 	for file in $(find "${S}/service/server/router/web" |grep -v png |grep -v index.html|grep -v .gz)


### PR DESCRIPTION
2.0.1加上NODE_OPTIONS=--openssl-legacy-provider会出现构建错误
去掉则可以成功构建