### PR TITLE
net-im/wemeet: add missing deps

### DIFF
--- a/net-im/wemeet/wemeet-3.12.0.400-r1.ebuild
+++ b/net-im/wemeet/wemeet-3.12.0.400-r1.ebuild
@@ -32,6 +32,8 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
+	dev-qt/qtwebsockets:5
+	dev-qt/qtwebview:5
 	media-libs/tiff-compat:4
 	media-sound/pulseaudio
 	x11-libs/libXinerama


### PR DESCRIPTION
和之前一样，如果没装这两个依赖，会不断触发rebuild