### PR TITLE
sys-kernel/xanmod-{sources,kernel}: slotmove 

### DIFF
--- a/profiles/updates/1Q-2023
+++ b/profiles/updates/1Q-2023
@@ -1,1 +1,5 @@
 slotmove net-im/tencent-qq nt 0
+slotmove sys-kernel/xanmod-sources stable 5.15.89
+slotmove sys-kernel/xanmod-sources edge 6.1.9
+slotmove sys-kernel/xanmod-kernel stable 5.15.89
+slotmove sys-kernel/xanmod-kernel edge 6.1.9

--- a/sys-kernel/xanmod-kernel/xanmod-kernel-5.15.89.ebuild
+++ b/sys-kernel/xanmod-kernel/xanmod-kernel-5.15.89.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,7 +23,7 @@ S=${WORKDIR}/${MY_P}
 LICENSE="GPL-2"
 KEYWORDS="~amd64"
 IUSE="cjk clang debug"
-SLOT="stable"
+SLOT="stable/${PV}"
 
 BDEPEND="
 	clang? (

--- a/sys-kernel/xanmod-kernel/xanmod-kernel-6.1.9.ebuild
+++ b/sys-kernel/xanmod-kernel/xanmod-kernel-6.1.9.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-2"
 KEYWORDS="~amd64"
 IUSE="cjk clang debug +x86-64-v1 x86-64-v2 x86-64-v3 x86-64-v4"
 REQUIRED_USE="^^ ( x86-64-v1 x86-64-v2 x86-64-v3 x86-64-v4 )"
-SLOT="edge"
+SLOT="edge/${PV}"
 
 PDEPEND="
 	>=virtual/dist-kernel-${PV}"

--- a/sys-kernel/xanmod-sources/xanmod-sources-5.15.89.ebuild
+++ b/sys-kernel/xanmod-sources/xanmod-sources-5.15.89.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
@@ -18,7 +18,7 @@ LICENSE+=" CDDL"
 KEYWORDS="~amd64"
 
 IUSE="cjktty"
-SLOT="stable"
+SLOT="stable/${PV}"
 XANMOD_VERSION="1"
 XANMOD_URI="https://github.com/xanmod/linux/releases/download/"
 OKV="${OKV}-xanmod"

--- a/sys-kernel/xanmod-sources/xanmod-sources-6.1.9.ebuild
+++ b/sys-kernel/xanmod-sources/xanmod-sources-6.1.9.ebuild
@@ -24,7 +24,7 @@ KEYWORDS="~amd64"
 #IUSE="cjktty tt"
 
 IUSE="cjktty"
-SLOT="edge"
+SLOT="edge/${PV}"
 XANMOD_VERSION="1"
 XANMOD_URI="https://github.com/xanmod/linux/releases/download/"
 OKV="${OKV}-xanmod"


### PR DESCRIPTION
我们目前是用stable和edge两个slot来区分xanmod-sources的稳定与否，这样的问题是无法保留老版本的内核源码。现在用subslot来区分稳定与否，便于保留旧的内核源码

可以先合并本pr，再合并 #2892
Signed-off-by: ston <ston.jia@qq.com>