### PR TITLE
dev-python / conda-package-streaming: {python-zstandard -> zstandard}

### DIFF
--- a/dev-python/conda-package-streaming/conda-package-streaming-0.7.0.ebuild
+++ b/dev-python/conda-package-streaming/conda-package-streaming-0.7.0.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="amd64 ~x86"
 
 DEPEND="
 	dev-python/requests[${PYTHON_USEDEP}]
-	dev-python/python-zstandard[${PYTHON_USEDEP}]"
+	dev-python/zstandard[${PYTHON_USEDEP}]"
 
 RDEPEND="${DEPEND}"
 BDEPEND=""


### PR DESCRIPTION
Rename dev-python/{python-zstandard → zstandard} in ::gentoo https://github.com/gentoo/gentoo/commit/8a4c2663ba1919bd2ef5237962cdbec5b31a156d