### PR TITLE
net-im/wemeet: fix SEGFAULT with libqxcb-glx-integration

### DIFF
--- a/net-im/wemeet/wemeet-3.12.0.400-r2.ebuild
+++ b/net-im/wemeet/wemeet-3.12.0.400-r2.ebuild
@@ -34,7 +34,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
-	|| ( media-libs/tiff:0/0 media-libs/tiff-compat:4 )
+	|| ( media-libs/tiff:0 media-libs/tiff-compat:4 )
 	media-sound/pulseaudio
 	x11-libs/libXinerama
 	x11-libs/libXrandr

--- a/net-im/wemeet/wemeet-3.12.0.400-r2.ebuild
+++ b/net-im/wemeet/wemeet-3.12.0.400-r2.ebuild
@@ -51,6 +51,8 @@ src_install() {
 	mkdir opt/${PN}/lib || die
 	cp -rf opt/${PN}/lib.orig/lib{bugly,crbase,desktop_common,ImSDK,nxui*,qt_*,service*,tms_*,ui*,wemeet*,xcast*,xnn*}.so opt/${PN}/lib/ || die
 	rm -r opt/${PN}/lib.orig || die
+	# Fix SEGFAULT with libqxcb-glx-integration
+	rm -r opt/wemeet/plugins/xcbglintegrations || die
 	# Fix RPATHs to ensure the libraries can be found
 	for f in $(find "opt/${PN}/bin" "opt/${PN}/plugins") ; do
 		[[ -f ${f} && $(od -t x1 -N 4 "${f}") == *"7f 45 4c 46"* ]] || continue


### PR DESCRIPTION
``opt/wemeet/plugins/xcbglintegrations`` causes wemeet to crash abnormally, it works fine after removing.