### PR TITLE
net-im/tencent-qq: add missing deps

### DIFF
--- a/net-im/tencent-qq/tencent-qq-3.1.0_p9572.ebuild
+++ b/net-im/tencent-qq/tencent-qq-3.1.0_p9572.ebuild
@@ -27,6 +27,7 @@ RDEPEND="
 	x11-libs/gtk+:3
 	x11-libs/libnotify
 	dev-libs/nss
+	dev-libs/libappindicator
 	x11-libs/libXScrnSaver
 	x11-libs/libXtst
 	x11-misc/xdg-utils


### PR DESCRIPTION
如果我们没加上libappindicator的依赖，qq的状态栏图标会变得非常糊糊