### PR TITLE
net-im/tencent-qq: limit version of glib

### DIFF
--- a/net-im/tencent-qq/tencent-qq-3.1.0_p9572.ebuild
+++ b/net-im/tencent-qq/tencent-qq-3.1.0_p9572.ebuild
@@ -35,6 +35,7 @@ RDEPEND="
 	app-crypt/libsecret
 	virtual/krb5
 	sys-apps/keyutils
+	<dev-libs/glib-2.76
 	bwrap? ( sys-apps/bubblewrap )
 "
 


### PR DESCRIPTION
如果glib版本为2.76及以上，会导致qq刷新到某些图片时崩溃，因此先限制glib的版本，等qq修复后再解除限制