### PR TITLE
x11-plugins/vicious: update EAPI=8 (fix nvchecker action)

### DIFF
--- a/x11-plugins/vicious/metadata.xml
+++ b/x11-plugins/vicious/metadata.xml
@@ -2,4 +2,10 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <!-- maintainer-needed -->
+	<use>
+		<flag name="contrib">Install extra widgets, some for less common hardware, some contributed by Vicious users.</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">vicious-widgets/vicious</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-plugins/vicious/vicious-9999.ebuild
+++ b/x11-plugins/vicious/vicious-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=8
 
 DESCRIPTION="Modular widget library for x11-wm/awesome"
 HOMEPAGE="http://awesome.naquadah.org/wiki/Vicious"
@@ -9,8 +9,6 @@ HOMEPAGE="http://awesome.naquadah.org/wiki/Vicious"
 if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="http://git.sysphere.org/${PN}"
-	SRC_URI=""
-	KEYWORDS=""
 else
 	SRC_URI="http://git.sysphere.org/${PN}/snapshot/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86"


### PR DESCRIPTION
inhert git-r3 not support EAPI=5 anymore (since https://github.com/gentoo/gentoo/commit/0dbbdfc6c6485614f2f84914dec2326cdb2a08e9), update to EAPI=8 here.

error catched in https://github.com/microcai/gentoo-zh/blob/df52f2ac08a26a169178c4fec3494425719dd5df/.github/workflows/nvchecker.yml#L33

```
gentoo-zh # egencache --jobs=$(nproc) --update --repo "$repo_name"
 * ERROR: x11-plugins/vicious-9999::gentoo-zh failed (depend phase):
 *   git-r3: EAPI 5 not supported
 *
 * Call stack:
 *             ebuild.sh, line 628:  Called source '/var/db/repos/gentoo-zh/x11-plugins/vicious/vicious-9999.ebuild'
 *   vicious-9999.ebuild, line  10:  Called inherit 'git-r3'
 *             ebuild.sh, line 308:  Called __qa_source '/var/db/repos/gentoo/eclass/git-r3.eclass'
 *             ebuild.sh, line 123:  Called source '/var/db/repos/gentoo/eclass/git-r3.eclass'
 *         git-r3.eclass, line  15:  Called die
 * The specific snippet of code:
 *   	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 *
 * If you need support, post the output of `emerge --info '=x11-plugins/vicious-9999::gentoo-zh'`,
 * the complete build log and the output of `emerge -pqv '=x11-plugins/vicious-9999::gentoo-zh'`.
 * Working directory: '/usr/lib/python3.10/site-packages'
 * S: '/var/tmp/portage/x11-plugins/vicious-9999/work/vicious-9999'
Error processing x11-plugins/vicious-9999, continuing...
```