### PR TITLE
actions: nvchecker: use GENTOO_ZH_NVCHECKER_PAT as github screct

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -68,6 +68,7 @@ jobs:
       env:
         pkgs: ${{steps.nvchecker.outputs.nvcmp}}
       with:
+        github-token: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }}
         script: |
           const script = require('./.github/workflows/issues-bumper.js');
           (async function () {


### PR DESCRIPTION
为了解决现在 nvchecker action 中的 rate limit, 需要 @microcai 帮忙生成一个PAT 代替 Github 服务器共享的 secret，个人 PAT 的配额为每小时 5000次，应该足够了
1. 在 https://github.com/settings/tokens/new 生成一个 PAT token (classic) ，过期时间可以选择永不过期，权限勾选 repo，Note 随意，其他的不需要选
2. 在 https://github.com/microcai/gentoo-zh/settings/secrets/actions 点击 `New repository secret` ， Name 为 GENTOO_ZH_NVCHECKER_PAT， secret 为第一步生成的 token

都处理完之后这个 PR 就可以合并了