### PR TITLE
app-office/bytedance-feishu: add x permission for vulcan_crashpad_handler

### DIFF
--- a/app-office/bytedance-feishu/bytedance-feishu-5.26.13-r1.ebuild
+++ b/app-office/bytedance-feishu/bytedance-feishu-5.26.13-r1.ebuild
@@ -67,6 +67,7 @@ src_install() {
 	fperms +x "/opt/bytedance/feishu/bytedance-feishu"
 	fperms +x "/opt/bytedance/feishu/feishu"
 	fperms +x "/opt/bytedance/feishu/vulcan/vulcan"
+	fperms +x "/opt/bytedance/feishu/vulcan/vulcan_crashpad_handler"
 
 }
 pkg_postinst(){


### PR DESCRIPTION
Cannot open documents / meetings / ... from feishu if `/opt/bytedance/feishu/vulcan/vulcan_crashpad_handler` is not executable.

Though, as the filename suggested, I don't think it's the root cause (perhaps it affects the logic about fallback or something...), giving it the executable permission will make `feishu` open the embedded "Vulcan" (which seems to be a browser based on chromium?) for these webpages.

I didn't test other versions, and I'm not sure whether other versions have the same file, so I only modified the latest version.