### PR TITLE
Add x86 for rime-data; Change blocking into requiring for rime-*

### DIFF
--- a/app-i18n/rime-bopomofo/rime-bopomofo-20210131.ebuild
+++ b/app-i18n/rime-bopomofo/rime-bopomofo-20210131.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 DEPEND="
 	app-i18n/rime-cangjie
 	app-i18n/rime-terra-pinyin
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 

--- a/app-i18n/rime-cangjie/rime-cangjie-20210223.ebuild
+++ b/app-i18n/rime-cangjie/rime-cangjie-20210223.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 
 DEPEND="
 	app-i18n/rime-luna-pinyin
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 

--- a/app-i18n/rime-data/rime-data-20220409.ebuild
+++ b/app-i18n/rime-data/rime-data-20220409.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://rime.im/"
 
 LICENSE="LGPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="
 	bopomofo
 	cangjie

--- a/app-i18n/rime-double-pinyin/rime-double-pinyin-20190120.ebuild
+++ b/app-i18n/rime-double-pinyin/rime-double-pinyin-20190120.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 DEPEND="
 	app-i18n/rime-luna-pinyin
 	app-i18n/rime-stroke
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 

--- a/app-i18n/rime-essay/rime-essay-20230204-r1.ebuild
+++ b/app-i18n/rime-essay/rime-essay-20230204-r1.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/rime/rime-bopomofo"
 LICENSE="LGPL-3"
 SLOT="0"
 
-DEPEND="!<app-i18n/rime-data-1"
+DEPEND=">=app-i18n/rime-data-1"
 RDEPEND="$DEPEND"
 
 S="${WORKDIR}"

--- a/app-i18n/rime-luna-pinyin/rime-luna-pinyin-20230204.ebuild
+++ b/app-i18n/rime-luna-pinyin/rime-luna-pinyin-20230204.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 
 DEPEND="
 	app-i18n/rime-stroke
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 

--- a/app-i18n/rime-pinyin-simp/rime-pinyin-simp-20230104.ebuild
+++ b/app-i18n/rime-pinyin-simp/rime-pinyin-simp-20230104.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 
 DEPEND="
 	app-i18n/rime-stroke
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 

--- a/app-i18n/rime-prelude/rime-prelude-20220122-r1.ebuild
+++ b/app-i18n/rime-prelude/rime-prelude-20220122-r1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/rime/rime-prelude"
 LICENSE="GPL-3"
 SLOT="0"
 
-DEPEND="!<app-i18n/rime-data-1"
+DEPEND=">=app-i18n/rime-data-1"
 RDEPEND="$DEPEND"
 
 S="${WORKDIR}/${PN}-${EGIT_COMMIT}"

--- a/app-i18n/rime-stroke/rime-stroke-20230204.ebuild
+++ b/app-i18n/rime-stroke/rime-stroke-20230204.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/rime/rime-stroke"
 LICENSE="LGPL-3"
 SLOT="0"
 
-DEPEND="!<app-i18n/rime-data-1"
+DEPEND=">=app-i18n/rime-data-1"
 RDEPEND="$DEPEND"
 
 S="${WORKDIR}/${PN}-${EGIT_COMMIT}"

--- a/app-i18n/rime-terra-pinyin/rime-terra-pinyin-20230207.ebuild
+++ b/app-i18n/rime-terra-pinyin/rime-terra-pinyin-20230207.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 
 DEPEND="
 	app-i18n/rime-luna-pinyin
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 

--- a/app-i18n/rime-wubi/rime-wubi-20200908.ebuild
+++ b/app-i18n/rime-wubi/rime-wubi-20200908.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 
 DEPEND="
 	app-i18n/rime-pinyin-simp
-	!<app-i18n/rime-data-1
+	>=app-i18n/rime-data-1
 "
 RDEPEND="$DEPEND"
 


### PR DESCRIPTION
之前没开`~`装fcitx-rime:5会因为gentoo-zh没开`~`被blocker挡住。我猜把blocker改成依赖高版本的话可能体验会好些？先改了试试等菊苣们看看效果