### PR TITLE
app-i18n/mozc: fix build w/ new abseil

### DIFF
--- a/app-i18n/mozc/files/mozc-2.28.5029.102-abseil.patch
+++ b/app-i18n/mozc/files/mozc-2.28.5029.102-abseil.patch
@@ -1,0 +1,15 @@
+https://bugs.gentoo.org/912776
+Adapted from https://src.fedoraproject.org/rpms/mozc/raw/aa3cba136c9a28e176d246f450465d3a8a4e8533/f/mozc-build-new-abseil.patch
+--- a/src/base/init_mozc.cc
++++ b/src/base/init_mozc.cc
+@@ -87,7 +87,10 @@ std::string GetLogFilePathFromProgramName(const std::string &program_name) {
+ void ParseCommandLineFlags(int argc, char **argv) {
+   absl::flags_internal::ParseCommandLineImpl(
+       argc, argv,
++      #if defined(ABSL_LTS_RELEASE_VERSION) && ABSL_LTS_RELEASE_VERSION < 20230802
++      // Abseil 20230802.0 does not use ArgvListAction
+       absl::flags_internal::ArgvListAction::kRemoveParsedArgs,
++      #endif
+       // Suppress help messages invoked by --help and others.
+       // Use UsageFlagsAction::kHandleUsage to enable it.
+       absl::flags_internal::UsageFlagsAction::kIgnoreUsage,

--- a/app-i18n/mozc/mozc-2.28.5029.102.ebuild
+++ b/app-i18n/mozc/mozc-2.28.5029.102.ebuild
@@ -131,6 +131,7 @@ SITEFILE="50${PN}-gentoo.el"
 
 PATCHES=(
 	"${WORKDIR}"/mozc-2.28.5029.102-patches
+	"${FILESDIR}"/mozc-2.28.5029.102-abseil.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
仅为跟进main tree的[commit](https://github.com/gentoo-mirror/gentoo/commit/7ef7e506b561a041e9ae1a66cb0a0a4ba6e009cd)。编译机上那个protobuf升级之后编译失败的我还完全不懂……反正不开~的我能编译过