### PR TITLE
net-im/dingtalk: fixed missing depend

### DIFF
--- a/net-im/dingtalk/dingtalk-7.0.40.30706.ebuild
+++ b/net-im/dingtalk/dingtalk-7.0.40.30706.ebuild
@@ -17,6 +17,7 @@ KEYWORDS="-* ~amd64"
 RESTRICT="strip mirror bindist"
 
 RDEPEND="
+	dev-libs/libthai
 	dev-qt/qtgui
 	media-libs/tiff-compat:4
 	media-libs/libpulse


### PR DESCRIPTION
```
yongxiang@5950x ~ $ dingtalk
gentoo
gentoo branch
preload_libs=
Load /opt/apps/com.alibabainc.dingtalk/files/7.0.40-Release.30706//dingtalk_dll.so failed! Err=libthai.so.0: cannot open shared object file: No such file or directory
```
