### PR TITLE
net-misc/baidunetdisk: fix not displayed bug on wayland

### DIFF
--- a/net-misc/baidunetdisk/baidunetdisk-4.17.7.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-4.17.7.ebuild
@@ -37,11 +37,12 @@ src_install() {
 	insinto /opt
 	doins -r opt/"${PN}"
 	fperms +x /opt/"${PN}"/"${PN}"
-	dosym -r /opt/{"${PN}"/"${PN}",bin/"${PN}"}
+	dobin "${FILESDIR}"/baidunetdisk
 
 	gzip -d usr/share/doc/"${PN}"/*.gz || die
 	dodoc usr/share/doc/"${PN}"/*
 
+	sed -i "s/Exec=.*/Exec=baidunetdisk %U/g" usr/share/applications/"${PN}".desktop
 	domenu usr/share/applications/"${PN}".desktop
 	doicon -s scalable usr/share/icons/hicolor/scalable/apps/"${PN}".svg
 }

--- a/net-misc/baidunetdisk/files/baidunetdisk
+++ b/net-misc/baidunetdisk/files/baidunetdisk
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if [ "${GDK_BACKEND}" = "wayland" ]; then
+    export GDK_BACKEND=x11
+    /opt/baidunetdisk/baidunetdisk --no-sandbox "$@"
+else
+    /opt/baidunetdisk/baidunetdisk --no-sandbox "$@"
+fi


### PR DESCRIPTION
The DISPLAY environment variable cannot be found on wayland, so determine whether it is wayland before starting, and make corrections.