### PR TITLE
net-im/wemeet: add dev-qt/qtwayland[compositor] as deps

### DIFF
--- a/net-im/wemeet/wemeet-3.15.1.401-r1.ebuild
+++ b/net-im/wemeet/wemeet-3.15.1.401-r1.ebuild
@@ -30,6 +30,7 @@ DEPEND="
 	dev-qt/qtnetwork:5
 	dev-qt/qtpositioning:5
 	dev-qt/qtprintsupport:5
+	dev-qt/qtwayland:5[compositor(+)]
 	dev-qt/qtwebchannel:5
 	dev-qt/qtwebengine:5
 	dev-qt/qtwebsockets:5
@@ -120,7 +121,7 @@ fi;
 	for i in 16 32 64 128 256; do
 		png_file="opt/${PN}/icons/hicolor/${i}x${i}/mimetypes/wemeetapp.png"
 		if [ -e "${png_file}" ]; then
-			newicon -s "${i}" "${png_file}" "wemeetapp.png"
+			newicon -s "${i}" -c mimetypes "${png_file}" "wemeetapp.png"
 		fi
 	done
 }


### PR DESCRIPTION
install hicolor icons as mimetypes context

```
!!! existing preserved libs:
>>> package: dev-qt/qtwayland-5.15.11
 *  - /usr/lib64/libQt5WaylandCompositor.so.5
 *  - /usr/lib64/libQt5WaylandCompositor.so.5.15.11
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-dmabuf-server-buffer.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-drm-egl-server-buffer.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-linux-dmabuf-unstable-v1.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-shm-emulation-server.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-wayland-egl.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-wayland-eglstream-controller.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-xcomposite-egl.so (net-im/wemeet-3.15.1.401)
 *      used by /opt/wemeet/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-xcomposite-glx.so (net-im/wemeet-3.15.1.401)
```