### PR TITLE
x11-misc/fqterm: Add qt5 deps slot

### DIFF
--- a/x11-misc/fqterm/fqterm-0.9.10.1.ebuild
+++ b/x11-misc/fqterm/fqterm-0.9.10.1.ebuild
@@ -17,13 +17,13 @@ IUSE=""
 RDEPEND="
 	dev-libs/openssl
 	media-libs/alsa-lib
-	dev-qt/qtcore
-	dev-qt/qtgui
-	dev-qt/qtnetwork
-	dev-qt/qtmultimedia
-	dev-qt/qtscript
-	dev-qt/qtwidgets
-	dev-qt/qtxml"
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtmultimedia:5
+	dev-qt/qtscript:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5"
 DEPEND="${RDEPEND}"
 
 src_prepare() {

--- a/x11-misc/fqterm/fqterm-9999.ebuild
+++ b/x11-misc/fqterm/fqterm-9999.ebuild
@@ -16,9 +16,9 @@ IUSE=""
 RDEPEND="
 	dev-libs/openssl
 	media-libs/alsa-lib
-	dev-qt/qtcore
-	dev-qt/qtgui
-	dev-qt/qtscript"
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtscript:5"
 DEPEND="${RDEPEND}"
 
 src_configure() {


### PR DESCRIPTION
这包的qt依赖都没指定slot，liang菊苣的测试机很多qt包都升了6卸了5，结果这包@preserved-rebuild就过不去了。加上5的slot应该会好？