### PR TITLE
net-im/dingtalk: fix dependencies

### DIFF
--- a/net-im/dingtalk/dingtalk-7.0.40.30706.ebuild
+++ b/net-im/dingtalk/dingtalk-7.0.40.30706.ebuild
@@ -30,6 +30,7 @@ RDEPEND="
 	x11-libs/gtk+:2
 	x11-libs/gtk+:3
 	x11-libs/libXScrnSaver
+	virtual/libcrypt
 "
 
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
According to Portage's QA notice, this is required