### PR TITLE
app-arch/zchunk: keyword 1.3.2 for ~riscv

### DIFF
--- a/app-arch/zchunk/zchunk-1.3.2.ebuild
+++ b/app-arch/zchunk/zchunk-1.3.2.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_CHECKOUT_DIR=${PN}-${PV}
 else
 	SRC_URI="https://github.com/zchunk/zchunk/archive/refs/tags/${PV}.tar.gz -> ${PN}-${PV}.tar.gz"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~riscv"
 	S="${WORKDIR}/${PN}-${PV}"
 fi
 


### PR DESCRIPTION
我在荔枝派4A上测试了可以用。
cc @liuyujielol  