### PR TITLE
net-misc/pcmanx-gtk2: fix #1396

### DIFF
--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit autotools flag-o-matic multilib
+inherit autotools flag-o-matic
 
 DESCRIPTION="PCMan is a gtk+ based free BBS client"
 HOMEPAGE="https://github.com/pcman-bbs/pcmanx"
@@ -18,7 +18,7 @@ RESTRICT="mirror"
 COMMON_DEPEND="
 	libnotify? ( x11-libs/libnotify )
 	x11-libs/libXft
-	>=x11-libs/gtk+-2.4:*
+	>=x11-libs/gtk+-2.4:2
 "
 
 RDEPEND="
@@ -32,7 +32,11 @@ DEPEND="
 	sys-devel/gettext
 "
 
+DOCS=( TODO README NEWS ChangeLog AUTHORS )
+
 src_prepare() {
+	eautoreconf
+
 	# this flag crashes CTermData::memset16()
 	filter-flags -ftree-vectorize
 	eapply_user

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
@@ -1,15 +1,16 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools flag-o-matic git-r3
 
 DESCRIPTION="PCMan is a gtk+ based free BBS client"
 HOMEPAGE="https://github.com/pcman-bbs/pcmanx"
-EGIT_REPO_URI="${HOMEPAGE}.git"
 
-KEYWORDS=""
+EGIT_REPO_URI="https://github.com/pcman-bbs/pcmanx.git"
+
+#KEYWORDS=""
 SLOT="0"
 LICENSE="GPL-2"
 IUSE="+libnotify +proxy iplookup +wget"
@@ -17,7 +18,7 @@ IUSE="+libnotify +proxy iplookup +wget"
 COMMON_DEPEND="
 	libnotify? ( x11-libs/libnotify )
 	x11-libs/libXft
-	>=x11-libs/gtk+-2.4:*
+	>=x11-libs/gtk+-2.4:2
 "
 
 RDEPEND="
@@ -31,10 +32,12 @@ DEPEND="
 	sys-devel/gettext
 "
 
+DOCS=( TODO README.md NEWS ChangeLog AUTHORS )
+
 src_prepare() {
 	[[ ! -e ChangeLog && -e ./build/changelog.sh ]] && \
 		./build/changelog.sh > ChangeLog
-	intltoolize --copy --force --automake || die "intltoolize failed"
+
 	eautoreconf
 
 	# this flag crashes CTermData::memset16()


### PR DESCRIPTION
update EAPI 7 -> 8

依赖>=x11-libs/gtk+-2.4:*的slot不对，导致tinderbox里面没有gtk2，只有gtk3