### PR TITLE
zypper nvcheck cleanup

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1034,12 +1034,6 @@ prefix = "v"
 # Yaourt is not maintained anymore
 #["sys-apps/yaourt"]
 
-["sys-apps/zypper"]
-source = "github"
-github = "openSUSE/zypper"
-use_latest_tag = true
-github_account = "HougeLangley"
-
 ["sys-boot/ventoy-bin"]
 source = "github"
 github = "ventoy/Ventoy"
@@ -1120,18 +1114,6 @@ github_account = "liuyujielol"
 
 # TODO
 #["sys-libs/libixp"]
-
-["sys-libs/libsolv"]
-source = "github"
-github = "openSUSE/libsolv"
-use_latest_tag = true
-github_account = "HougeLangley"
-
-["sys-libs/libzypp"]
-source = "github"
-github = "openSUSE/libzypp"
-use_latest_tag= true
-github_account = "HougeLangley"
 
 # virtual, do nothing
 #["virtual/dist-kernel"]


### PR DESCRIPTION
- .github/workflows: clean zypper related packages

fixed: https://github.com/microcai/gentoo-zh/issues/3893
fixed: https://github.com/microcai/gentoo-zh/issues/3894
fixed: https://github.com/microcai/gentoo-zh/issues/3895
