### PR TITLE
sys-kernel/xanmod-rt: fixed symlink not working

### DIFF
--- a/sys-kernel/xanmod-rt/xanmod-rt-6.0.11.ebuild
+++ b/sys-kernel/xanmod-rt/xanmod-rt-6.0.11.ebuild
@@ -59,4 +59,6 @@ pkg_postinst() {
 	elog "MICROCODES"
 	elog "Use xanmod-sources with microcodes"
 	elog "Read https://wiki.gentoo.org/wiki/Intel_microcode"
+
+	postinst_sources
 }


### PR DESCRIPTION
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

fixed: https://github.com/microcai/gentoo-zh/issues/2812
