### PR TITLE
.github/workflows: clean unused package

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -860,11 +860,6 @@ source = "github"
 github = "pcman-bbs/pcmanx"
 use_latest_release = true
 
-["net-misc/postman-bin"]
-source = "aur"
-aur = "postman-bin"
-strip_release = 'yes'
-
 ["net-misc/prips"]
 source = "regex"
 url = "https://devel.ringlet.net/sysutils/prips/"


### PR DESCRIPTION
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

fixed: https://github.com/microcai/gentoo-zh/issues/3914
