### PR TITLE
dev-util/gyp: DISTUTILS_USE_PEP517

### DIFF
--- a/dev-util/gyp/gyp-20230914150222.ebuild
+++ b/dev-util/gyp/gyp-20230914150222.ebuild
@@ -4,19 +4,19 @@
 EAPI="8"
 PYTHON_COMPAT=( python3_{10..12} )
 DISTUTILS_SINGLE_IMPL="1"
+DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1
+
+DESCRIPTION="GYP (Generate Your Projects) meta-build system"
+HOMEPAGE="https://gyp.gsrc.io/ https://chromium.googlesource.com/external/gyp"
+COMMIT="a03d7413becefc8d55c8aa3df58b55b9bd0e9052"
 
 if [[ "${PV}" == "99999999999999" ]]; then
 	inherit git-r3
 
 	EGIT_REPO_URI="https://chromium.googlesource.com/external/gyp"
-fi
-
-DESCRIPTION="GYP (Generate Your Projects) meta-build system"
-HOMEPAGE="https://gyp.gsrc.io/ https://chromium.googlesource.com/external/gyp"
-COMMIT="a03d7413becefc8d55c8aa3df58b55b9bd0e9052"
-if [[ "${PV}" != "99999999999999" ]]; then
+else
 	inherit vcs-snapshot
 
 	SRC_URI="https://github.com/chromium/${PN}/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"

--- a/dev-util/gyp/gyp-99999999999999.ebuild
+++ b/dev-util/gyp/gyp-99999999999999.ebuild
@@ -4,6 +4,7 @@
 EAPI="8"
 PYTHON_COMPAT=( python3_{10..12} )
 DISTUTILS_SINGLE_IMPL="1"
+DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1
 
@@ -13,8 +14,6 @@ HOMEPAGE="https://gyp.gsrc.io/ https://chromium.googlesource.com/external/gyp"
 if [[ "${PV}" == "99999999999999" ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://chromium.googlesource.com/external/gyp"
-else
-	SRC_URI="https://home.apache.org/~arfrever/distfiles/${P}.tar.xz"
 fi
 
 LICENSE="BSD"


### PR DESCRIPTION
pkgcheck scan:
```
DistutilsNonPEP517Build: version 20230914150222: uses deprecated non-PEP517 build mode, please switch to DISTUTILS_USE_PEP517=...
DistutilsNonPEP517Build: version 99999999999999: uses deprecated non-PEP517 build mode, please switch to DISTUTILS_USE_PEP517=...
```
github并不是upstream是mirror，没有加到metadata