### PR TITLE
net-im/dingtalk:add missing dependency

### DIFF
--- a/net-im/dingtalk/dingtalk-7.1.0.31120.ebuild
+++ b/net-im/dingtalk/dingtalk-7.1.0.31120.ebuild
@@ -17,6 +17,7 @@ KEYWORDS="-* ~amd64"
 RESTRICT="strip mirror bindist"
 
 RDEPEND="
+	dev-libs/wayland
 	dev-libs/libthai
 	dev-qt/qtgui
 	media-libs/tiff-compat:4


### PR DESCRIPTION
添加缺少的依赖项`dev-libs/wayland`#4028 