### PR TITLE
sys-fs/spadfs-utils: all-rights-reserved license restricts

### DIFF
--- a/sys-fs/spadfs-utils/spadfs-utils-1.0.18.ebuild
+++ b/sys-fs/spadfs-utils/spadfs-utils-1.0.18.ebuild
@@ -10,6 +10,7 @@ HOMEPAGE="http://www.jikos.cz/~mikulas/spadfs/"
 SRC_URI="http://www.jikos.cz/~mikulas/spadfs/download/spadfs-${PV}.tar.gz"
 
 LICENSE="all-rights-reserved"
+RESTRICT="bindist mirror"
 SLOT="0"
 KEYWORDS="~amd64"
 S="${WORKDIR}/spadfs-${PV}"


### PR DESCRIPTION
from devmanual.gentoo.org: 
 If the package does not indicate any license, then you should contact the author for clarification. Adding packages with no explicit license statement is strongly discouraged. If they are present already, they ought to have all-rights-reserved license, and **RESTRICT="bindist mirror".** 