### PR TITLE
.github/workflows: add missing latest tag field

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -176,6 +176,7 @@ github_account = "oatiz"
 source = "github"
 github = "anyproto/anytype-ts"
 prefix = "v"
+use_latest_tag = true
 include_regex = '^v\d+(\.\d+)*$'
 github_account = "xz-dev"
 


### PR DESCRIPTION
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

fix: https://github.com/microcai/gentoo-zh/issues/4142
