### PR TITLE
x11-themes/klassy: move {kde-frameworks -> kde-plasma}/kwayland

### DIFF
--- a/x11-themes/klassy/klassy-4.0.5.25.80-r1.ebuild
+++ b/x11-themes/klassy/klassy-4.0.5.25.80-r1.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	x11-themes/hicolor-icon-theme
 	kde-plasma/kdecoration:5
 	kde-frameworks/kirigami:5
-	kde-frameworks/kwayland:5
+	kde-plasma/kwayland:5
 	kde-frameworks/extra-cmake-modules:0
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

fix: https://github.com/microcai/gentoo-zh/issues/4187
