### PR TITLE
app-crypt/archlinux-keyring: add 20240208-r1, drop 20240208

### DIFF
--- a/app-crypt/archlinux-keyring/archlinux-keyring-20240208-r1.ebuild
+++ b/app-crypt/archlinux-keyring/archlinux-keyring-20240208-r1.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://gitlab.archlinux.org/archlinux/${PN}/-/archive/${PV}/${P}.tar.b
 LICENSE="GPL-2" # "GPL" for the Arch linux package
 SLOT="0"
 KEYWORDS="~amd64"
-BDEPEND="app-crypt/sequoia-sq"
+BDEPEND=">=app-crypt/sequoia-sq-0.33.0"
 
 src_compile(){
 	emake build


### PR DESCRIPTION
As of [this commit](https://gitlab.archlinux.org/archlinux/archlinux-keyring/-/commit/57714dd986a329c3d281e330e2e86a340ae8770b) app-crypt/archlinux-keyring requires >=app-crypt/sequoia-sq-0.33.0 in order to build successfully. At the time of writing this 0.33.0 is marked testing in the official gentoo repo.