### PR TITLE
net-proxy/v2ray-bin: improve dependencies

### DIFF
--- a/net-proxy/v2ray-bin/v2ray-bin-4.45.0-r1.ebuild
+++ b/net-proxy/v2ray-bin/v2ray-bin-4.45.0-r1.ebuild
@@ -25,12 +25,11 @@ KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 
 RESTRICT="mirror"
 
-DEPEND="
+RDEPEND="
 	!net-proxy/v2ray
 	!app-alternatives/v2ray-geoip
 	!app-alternatives/v2ray-geosite
 "
-RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
 QA_PREBUILT="
 	/usr/bin/v2ray

--- a/net-proxy/v2ray-bin/v2ray-bin-5.12.1.ebuild
+++ b/net-proxy/v2ray-bin/v2ray-bin-5.12.1.ebuild
@@ -26,12 +26,11 @@ KEYWORDS="-* ~amd64 ~arm ~arm64 ~x86"
 
 RESTRICT="mirror"
 
-DEPEND="
+RDEPEND="
 	!net-proxy/v2ray
 	!app-alternatives/v2ray-geoip
 	!app-alternatives/v2ray-geosite
 "
-RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
 QA_PREBUILT="
 	/usr/bin/v2ray


### PR DESCRIPTION
[Devmanual](https://devmanual.gentoo.org/general-concepts/dependencies/#blockers):

> Weak blockers are usually used to solve file collisions between packages and are meaningful only in RDEPEND.