### PR TITLE
app-editors/typora: fix link for 0.11.18 free version

### DIFF
--- a/app-editors/typora/typora-0.11.18.ebuild
+++ b/app-editors/typora/typora-0.11.18.ebuild
@@ -1,46 +1,42 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit desktop
+inherit desktop unpacker xdg
 
 DESCRIPTION="Typora will give you a seamless experience as both a reader and a writer."
 HOMEPAGE="https://typora.io"
-SRC_URI="https://hougearch.litterhougelangley.club/src/typora_${PV}_amd64.deb"
+SRC_URI="https://web.archive.org/web/20211127121316if_/https://typora.io/linux/typora_${PV}_amd64.deb"
 
 #TODO : update license
 LICENSE="typora"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="-* ~amd64"
 
 RESTRICT="mirror"
 
 RDEPEND="x11-libs/libXScrnSaver"
 
+S="${WORKDIR}/usr"
+
 QA_PREBUILT="*"
 
-src_unpack() {
+src_prepare() {
+	rm -rf share/lintian || die
+	sed -i '/Change Log/d' share/applications/typora.desktop || die
 	default
-	unpack "${WORKDIR}"/data.tar.xz
-	S="${WORKDIR}/usr"
 }
 
 src_install() {
 	local dir="/opt/${PN}"
 
 	insinto "${dir}"
-	rm -rf share/lintian
-	sed -i '/Change Log/d' share/applications/typora.desktop
 	doins -r bin share
 
 	fperms 0755 "${dir}/bin/typora"
 	fperms 4755 "${dir}/share/typora/chrome-sandbox"
-	dosym "../../opt/typora/bin/typora" "usr/bin/typora"
+	dosym -r /opt/typora/bin/typora /usr/bin/typora
 
 	domenu share/applications/typora.desktop
-}
-
-pkg_postinst() {
-	update-desktop-database
 }


### PR DESCRIPTION
免费版之前是Houge菊苣在自己的服务器上host，结果上次升23.0 profile的时候发现拿掉了，于是学AUR那边改用了web archive。顺便手欠升了EAPI和ebuild header然后把语法改顺便了一点点（强迫症发作😷