### PR TITLE
Update liblol website

### DIFF
--- a/app-emulation/liblol-glibc/liblol-glibc-0.1.5_pre6.ebuild
+++ b/app-emulation/liblol-glibc/liblol-glibc-0.1.5_pre6.ebuild
@@ -12,7 +12,7 @@ TMPFILES_OPTIONAL=1
 inherit python-any-r1 toolchain-funcs flag-o-matic gnuconfig multilib tmpfiles
 
 DESCRIPTION="GNU libc C library, for liblol"
-HOMEPAGE="https://www.gnu.org/software/libc/ https://github.com/AOSC-Dev/liblol"
+HOMEPAGE="https://www.gnu.org/software/libc/ https://liblol.aosc.io"
 LICENSE="LGPL-2.1+ BSD HPND ISC inner-net rc PCRE"
 SLOT="2.2"
 

--- a/app-emulation/liblol-libxcrypt/liblol-libxcrypt-0.1.5_pre6.ebuild
+++ b/app-emulation/liblol-libxcrypt/liblol-libxcrypt-0.1.5_pre6.ebuild
@@ -17,7 +17,7 @@ XC_P="libxcrypt-${XC_PV}"
 LOLPREFIX=/opt/lol
 
 DESCRIPTION="libxcrypt for liblol"
-HOMEPAGE="https://github.com/besser82/libxcrypt https://github.com/AOSC-Dev/liblol"
+HOMEPAGE="https://github.com/besser82/libxcrypt https://liblol.aosc.io"
 if [[ ${NEED_BOOTSTRAP} == "yes" ]] ; then
 	inherit autotools
 	SRC_URI="https://github.com/besser82/libxcrypt/releases/download/v${XC_PV}/${XC_P}.tar.xz"

--- a/app-emulation/liblol/liblol-0.1.5_pre6.ebuild
+++ b/app-emulation/liblol/liblol-0.1.5_pre6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="LoongArch old-world ABI compatibility layer from AOSC OS"
-HOMEPAGE="https://github.com/AOSC-Dev/liblol"
+HOMEPAGE="https://liblol.aosc.io"
 
 # liblol itself is licensed under GPL-2 according to the AOSC maintainers.
 LICENSE="GPL-2"

--- a/dev-util/patchelf-liblol/patchelf-liblol-0.1.4.ebuild
+++ b/dev-util/patchelf-liblol/patchelf-liblol-0.1.4.ebuild
@@ -10,7 +10,7 @@ PATCHELF_PV=0.18.0
 PATCHELF_P="${PATCHELF_PN}-${PATCHELF_PV}"
 
 DESCRIPTION="patchelf patched for building libLoL only"
-HOMEPAGE="https://github.com/NixOS/patchelf https://github.com/AOSC-Dev/liblol"
+HOMEPAGE="https://github.com/NixOS/patchelf https://liblol.aosc.io"
 SRC_URI="https://github.com/NixOS/${PATCHELF_PN}/archive/${PATCHELF_PV}.tar.gz -> ${PATCHELF_P}.tar.gz"
 S="${WORKDIR}/${PATCHELF_P}"
 


### PR DESCRIPTION
They now have a project homepage, so link to that instead of the repository.