### PR TITLE
x11-misc/snapd-xdg-open: keyword 20170401 for ~loong

### DIFF
--- a/x11-misc/snapd-xdg-open/snapd-xdg-open-20170401.ebuild
+++ b/x11-misc/snapd-xdg-open/snapd-xdg-open-20170401.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/snapcore/snapd-xdg-open/archive/${EGIT_COMMIT}.tar.g
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64"
+KEYWORDS="~amd64 ~arm64 ~loong"
 
 S="${WORKDIR}/${PN}-${EGIT_COMMIT}"
 


### PR DESCRIPTION
net-im/tencent-qq/tencent-qq-3.2.7_p240410.ebuild 依赖项