### PR TITLE
media-sound/go-musicfox: add keyword for ~loong

### DIFF
--- a/media-sound/go-musicfox/go-musicfox-4.3.3.ebuild
+++ b/media-sound/go-musicfox/go-musicfox-4.3.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/go-musicfox/go-musicfox/archive/refs/tags/v${PV}.tar
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~loong"
 IUSE="clang"
 RESTRICT="mirror"
 


### PR DESCRIPTION
启用loong keyword，IUSE gcc/clang 下均测试正常运行、播放。