### PR TITLE
 actions: nvchecker: fix search failed when more than 1000 issues

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -76,7 +76,7 @@ jobs:
       env:
         pkgs: ${{steps.nvchecker.outputs.nvcmp}}
       with:
-        github-token: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }}
+        github-token: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }} # https://github.com/microcai/gentoo-zh/pull/3130
         script: |
           const script = require('./.github/workflows/issues-bumper.js');
           (async function () {


### PR DESCRIPTION
github rest 接口最大返回 1000 个搜索结果，之前搜索时使用的关键词为 `[nvchecker] can be bump to`，已经超过此限制。

![image](https://github.com/microcai/gentoo-zh/assets/624223/3c7dd04a-5a81-4d6d-864a-b18eb8e519e0)

![image](https://github.com/microcai/gentoo-zh/assets/624223/777e3b6e-26d2-47f6-adea-eed6c3826c97)

将包名加入了搜索关键词，例如 `[nvchecker] net-vpn/tailscale can be bump to`，现阶段单个包的搜索结果小于20个。我相信不会有包会更新1000个版本，开1000个 issues。如果发生了这种情况，可以之后再细化搜索关键词，比如按年查询


