### PR TITLE
Improve dependencies on app-alternatives/v2ray-geo{ip,site}

### DIFF
--- a/net-dns/mosdns-cn-bin/mosdns-cn-bin-1.4.0-r1.ebuild
+++ b/net-dns/mosdns-cn-bin/mosdns-cn-bin-1.4.0-r1.ebuild
@@ -7,27 +7,33 @@ DESCRIPTION="A DNS forwarder"
 HOMEPAGE="https://github.com/IrineSistiana/mosdns-cn"
 SRC_URI="https://github.com/IrineSistiana/mosdns-cn/releases/download/v${PV}/mosdns-cn-linux-amd64.zip -> ${P}.zip"
 
+S=${WORKDIR}
+
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
 
+RESTRICT="mirror"
+
 DEPEND="
-	dev-libs/v2ray-domain-list-community-bin
-	dev-libs/v2ray-geoip-bin
+	app-alternatives/v2ray-geoip
+	app-alternatives/v2ray-geosite
 "
 RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
-
-S=${WORKDIR}
+QA_PREBUILT="
+	/usr/bin/mosdns-cn
+"
 
 src_install() {
 	dobin mosdns-cn
 
+	dosym -r /usr/share/v2ray/geoip.dat /etc/mosdns/geoip.dat
+	dosym -r /usr/share/v2ray/geosite.dat /etc/mosdns/geosite.dat
+
 	insinto /etc/mosdns
-	ln -s /usr/share/v2ray/geoip.dat geoip.dat
-	ln -s /usr/share/v2ray/geosite.dat geosite.dat
-	doins geoip.dat geosite.dat
 	newins config-template.yaml config.yaml
+
 	_PN=mosdns-cn
 	newinitd "${FILESDIR}/${_PN}.initd" ${_PN}
 	newconfd "${FILESDIR}/${_PN}.confd" ${_PN}

--- a/net-proxy/Xray/Xray-1.8.11.ebuild
+++ b/net-proxy/Xray/Xray-1.8.11.ebuild
@@ -18,8 +18,9 @@ KEYWORDS="~amd64 ~arm ~arm64 ~loong ~riscv ~x86"
 
 RESTRICT="mirror"
 
-RDEPEND="app-alternatives/v2ray-geoip
+DEPEND="app-alternatives/v2ray-geoip
 	app-alternatives/v2ray-geosite"
+RDEPEND="${DEPEND}"
 BDEPEND=">=dev-lang/go-1.22"
 
 src_compile() {

--- a/net-proxy/clash-nyanpasu/clash-nyanpasu-1.5.1.ebuild
+++ b/net-proxy/clash-nyanpasu/clash-nyanpasu-1.5.1.ebuild
@@ -782,6 +782,8 @@ REQUIRED_USE="
 "
 
 DEPEND="
+	app-alternatives/v2ray-geoip
+	app-alternatives/v2ray-geosite
 	dev-libs/glib:2
 	dev-libs/openssl:=
 	dev-libs/libayatana-appindicator
@@ -793,8 +795,6 @@ DEPEND="
 "
 RDEPEND="
 	${DEPEND}
-	app-alternatives/v2ray-geoip
-	app-alternatives/v2ray-geosite
 	clash-rs? ( net-proxy/clash-rs )
 	mihomo? ( net-proxy/mihomo )
 "

--- a/net-proxy/v2ray-bin/v2ray-bin-4.45.0-r2.ebuild
+++ b/net-proxy/v2ray-bin/v2ray-bin-4.45.0-r2.ebuild
@@ -25,10 +25,13 @@ KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 
 RESTRICT="mirror"
 
+DEPEND="
+	app-alternatives/v2ray-geoip
+	app-alternatives/v2ray-geosite
+"
 RDEPEND="
 	!net-proxy/v2ray
-	!app-alternatives/v2ray-geoip
-	!app-alternatives/v2ray-geosite
+	${DEPEND}
 "
 BDEPEND="app-arch/unzip"
 QA_PREBUILT="
@@ -46,9 +49,6 @@ src_unpack() {
 src_install() {
 	dobin v2ray
 	dobin v2ctl
-
-	insinto /usr/share/v2ray
-	doins *.dat
 
 	insinto /etc/v2ray
 	doins *.json

--- a/net-proxy/v2ray-bin/v2ray-bin-5.12.1-r1.ebuild
+++ b/net-proxy/v2ray-bin/v2ray-bin-5.12.1-r1.ebuild
@@ -20,29 +20,29 @@ SRC_URI="
 	)
 "
 
+S=${WORKDIR}
+
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm ~arm64 ~x86"
 
 RESTRICT="mirror"
 
+DEPEND="
+	app-alternatives/v2ray-geoip
+	app-alternatives/v2ray-geosite
+"
 RDEPEND="
 	!net-proxy/v2ray
-	!app-alternatives/v2ray-geoip
-	!app-alternatives/v2ray-geosite
+	${DEPEND}
 "
 BDEPEND="app-arch/unzip"
 QA_PREBUILT="
 	/usr/bin/v2ray
 "
 
-S=${WORKDIR}
-
 src_install() {
 	dobin v2ray
-
-	insinto /usr/share/v2ray
-	doins *.dat
 
 	insinto /etc/v2ray
 	doins *.json

--- a/net-proxy/v2ray/v2ray-5.15.3.ebuild
+++ b/net-proxy/v2ray/v2ray-5.15.3.ebuild
@@ -20,8 +20,8 @@ RESTRICT="mirror"
 
 DEPEND="app-alternatives/v2ray-geoip
 	app-alternatives/v2ray-geosite"
-RDEPEND="${DEPEND}
-	!net-proxy/v2ray-bin"
+RDEPEND="!net-proxy/v2ray-bin
+	${DEPEND}"
 BDEPEND=">=dev-lang/go-1.21.4"
 
 src_prepare() {

--- a/net-proxy/v2ray/v2ray-5.16.1.ebuild
+++ b/net-proxy/v2ray/v2ray-5.16.1.ebuild
@@ -20,8 +20,8 @@ RESTRICT="mirror"
 
 DEPEND="app-alternatives/v2ray-geoip
 	app-alternatives/v2ray-geosite"
-RDEPEND="${DEPEND}
-	!net-proxy/v2ray-bin"
+RDEPEND="!net-proxy/v2ray-bin
+	${DEPEND}"
 BDEPEND=">=dev-lang/go-1.21.4"
 
 src_prepare() {


### PR DESCRIPTION
- net-proxy/v2ray-bin now depends on app-alternatives/v2ray-geo{ip,site} to avoid conflict.
- net-dns/mosdns-cn-bin now also depends on them.
- Others: RDEPEND -> DEPEND, 

> Build dependencies are used to specify any dependencies that are required to unpack, patch, compile, test or install the package.