### PR TITLE
net-im/tencent-qq: fix 3.2.8_p24520 LiteLoaderQQNT Failure Issue

### DIFF
--- a/net-im/tencent-qq/files/start.sh
+++ b/net-im/tencent-qq/files/start.sh
@@ -75,7 +75,7 @@ fi
 rm -rf "${QQ_HOTUPDATE_DIR}/"**".zip"
 is_hotupdated_version=0  # 正在运行的版本是否经过热更新？
 
-find "${QQ_HOTUPDATE_DIR}/"*-* -maxdepth 1 -type "d,l" | while read path; do
+find "${QQ_HOTUPDATE_DIR}/"*[-_]* -maxdepth 1 -type "d,l" | while read path; do
     this_version="$(basename "$path")"
     if [ "$(/opt/QQ/workarounds/vercmp.sh "${this_version}" lt "${QQ_HOTUPDATE_VERSION//_/-}")" == "true" ]; then
         # 这个版本小于当前版本，删除之
@@ -116,6 +116,7 @@ bwrap --new-session --cap-drop ALL --unshare-user-try --unshare-pid --unshare-cg
     --bind-try "${HOME}/.pki" "${HOME}/.pki" \
     --ro-bind-try "${XAUTHORITY}" "${XAUTHORITY}" \
     --bind-try "${QQ_DOWNLOAD_DIR}" "${QQ_DOWNLOAD_DIR}" \
+    --setenv QQ_APP_DIR "${QQ_APP_DIR}" \
     --bind "${QQ_APP_DIR}" "${QQ_APP_DIR}" \
     --ro-bind-try "${FONTCONFIG_HOME}" "${FONTCONFIG_HOME}" \
     --ro-bind-try "${HOME}/.icons" "${HOME}/.icons" \

--- a/net-im/tencent-qq/tencent-qq-3.2.8_p240520-r1.ebuild
+++ b/net-im/tencent-qq/tencent-qq-3.2.8_p240520-r1.ebuild
@@ -6,14 +6,17 @@ EAPI=8
 inherit unpacker xdg
 
 MY_PV=${PV/_p/_}
+_QQDownSite="https://dldir1.qq.com/qqfile/qq/QQNT/Linux"
+_QQFileName="QQ"
+_QQFileSuffix="_01.deb"
 _LiteLoader_PV="1.1.1"
 DESCRIPTION="The new version of the official linux-qq"
 HOMEPAGE="https://im.qq.com/linuxqq/index.shtml"
 
 SRC_URI="
-	amd64? ( https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_${MY_PV}_amd64_01.deb )
-	arm64? ( https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_${MY_PV}_arm64_01.deb )
-	loong? ( https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_${MY_PV}_loongarch64_01.deb )
+	amd64? ( ${_QQDownSite}/${_QQFileName}_${MY_PV}_amd64${_QQFileSuffix} )
+	arm64? ( ${_QQDownSite}/${_QQFileName}_${MY_PV}_arm64${_QQFileSuffix} )
+	loong? ( ${_QQDownSite}/${_QQFileName}_${MY_PV}_loongarch64${_QQFileSuffix} )
 	liteloader? (
 		https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/releases/download/${_LiteLoader_PV}/LiteLoaderQQNT.zip \
 		-> LiteLoaderQQNT-${_LiteLoader_PV}.zip
@@ -67,7 +70,11 @@ src_unpack() {
 src_install() {
 	dodir /
 	cd "${D}" || die
-	unpacker "${DISTDIR}/linuxqq_${MY_PV}_${ARCH}".deb
+	if [ "${ARCH}" = "loong" ]; then
+		unpacker "${DISTDIR}/${_QQFileName}_${MY_PV}_loongarch64${_QQFileSuffix}"
+	else
+		unpacker "${DISTDIR}/${_QQFileName}_${MY_PV}_${ARCH}${_QQFileSuffix}"
+	fi
 
 	if use system-vips; then
 		rm -r "${D}"/opt/QQ/resources/app/sharp-lib || die
@@ -123,7 +130,22 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 	if use bwrap; then
+		elog "-EN-----------------------------------------------------------------"
 		elog "If you want to download files in QQ"
 		elog "Please set the QQ download path to ~/Download"
+		elog "If you have enabled LiteLoaderQQNT support, relevant plugins can be "
+		elog "downloaded from https://liteloaderqqnt.github.io/, "
+		elog "For instance, after downloading the 「轻量工具箱」 and unzipping it, "
+		elog "download it to the directory ~/.config/QQ/LiteLoaderQQNT/plugins/lite_tools_v4/, "
+		elog "and the changes will take effect after a restart."
+		elog "--------------------------------------------------------------------"
+		elog "-ZH-----------------------------------------------------------------"
+		elog "如果要在 QQ 中下载文件，请先在「设置」->「存储管理」中把下载文件夹"
+		elog "更改为系统的“下载”/“Downloads”文件夹。"
+		elog "如果您启用了 LiteLoaderQQNT 支持，"
+		elog "可以从 https://liteloaderqqnt.github.io/ 下载相关插件，"
+		elog "例如：「轻量工具箱」下载后"
+		elog "解压到 ~/.config/QQ/LiteLoaderQQNT/plugins/“lite_tools_v4”/ 目录下，重启后生效。"
+		elog "--------------------------------------------------------------------"
 	fi
 }


### PR DESCRIPTION
1、将下载链接及QQ文件名变量化，以减少未来更新行数（QQ发布时有两种文件名格式，原因不详）。
2、由于龙芯的ARCH信息是loong，QQ文件名是loongarch64会导致解决LiteLoaderQQNT下在龙芯上安装失败问题。
3、追加中文描述信息。
4、参考 AUR 添加了环境变量 https://aur.archlinux.org/cgit/aur.git/tree/start.sh?h=linuxqq-nt-bwrap 。
fix:https://github.com/microcai/gentoo-zh/issues/4654

#### 没有X86环境，麻烦老师帮忙测试以下开启/关闭liteloader选项时，安装是否正常，谢谢