### PR TITLE
profiles/package.use.mask: Create a package.use.mask file and mask the net-im/tencent-qq liteloader option in it.

### DIFF
--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -1,0 +1,10 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Haowu Ge <gehaowu@bitmoe.com> (2024-05-26)
+# LiteLoaderQQNT is a hacking tool,
+# Employing it breaches the end-user license agreement,
+# could potentially destabilize the main program, or
+# lead to account suspension.
+# Please exercise caution when enabling it.
+net-im/tencent-qq liteloader


### PR DESCRIPTION
由于liteloader有外挂性质，使用违反使用许可，可能会导致QQ账号被封，设置默认不启用


[QQ软件许可及服务协议](https://rule.tencent.com/rule/46a15f24-e42c-4cb6-a308-2347139b1201)

```
8.2.2 软件使用
除非法律法规允许或腾讯书面许可，您不得从事下列行为：
（1）删除本软件及其副本上关于著作权的信息。
（2）对本软件进行反向工程、反向汇编、反向编译，或者以其他方式尝试发现本软件的源代码。
（3）对腾讯拥有知识产权的内容进行使用、出租、出借、复制、修改、链接、转载、汇编、发表、出版、建立镜像站点等。
（4）对本软件或者本软件运行过程中释放到任何终端内存中的数据、软件运行过程中客户端与服务器端的交互数据，以及本软件运行所必需的系统数据，进行复制、修改、增加、删除、挂接运行或创作任何衍生作品，形式包括但不限于使用插件、外挂或非腾讯经授权的第三方工具/服务接入本软件和相关系统。
（5）通过修改或伪造软件运行中的指令、数据，增加、删减、变动软件的功能或运行效果，或者将用于上述用途的软件、方法进行运营或向公众传播，无论这些行为是否为商业目的。
（6）通过非腾讯开发、授权的第三方软件、插件、外挂、系统，登录或使用本软件和/或本服务，或制作、发布、传播上述工具。
（7）自行、授权他人或利用第三方软件对本软件和/或本服务及其组件、模块、数据等进行干扰。
（8）其他可能影响、干扰本软件和/或本服务正常运行的行为。
```