### PR TITLE
add .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -63,8 +63,6 @@ jobs:
 
     - name: setup node
       uses: actions/setup-node@v2
-      with:
-        node-version: 16
 
     - name: install github-script depends
       run: |


### PR DESCRIPTION
尽管 bump actions 大版本不是那么重要（<del>老版本又不是不能用</del>），我有时还是忍不住想要消除警告⚠️，让 actions 好看一点。

就让勤劳的 dependabot 来帮我们干这件事吧！

![image](https://github.com/microcai/gentoo-zh/assets/624223/ce1fa621-8e3c-4b92-9d68-a9e4b34ec3d0)
