### PR TITLE
actions: nvchecker: fix node-version

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -62,7 +62,9 @@ jobs:
         echo "::endgroup::"
 
     - name: setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
+      with:
+        node-version: latest
 
     - name: install github-script depends
       run: |


### PR DESCRIPTION
上次提交 48e68abc6b9cee50abc70a5e9ffde0bbd8bc2817 删除了 node-version，导致 `npm install toml` 时会出现  npm not found 的报错