### PR TITLE
deps-table: update deprecated set-output

### DIFF
--- a/update-relation.sh
+++ b/update-relation.sh
@@ -16,7 +16,7 @@ if [[ ${_gitdiff%% } != '@@ -1,6 +1,6 @@' ]]; then
   git config --local user.name "github-actions[bot]"
   git add .
   git commit -m "${ctime} (updated)"
-  echo "::set-output name=state::changed"
+  echo "state=changed" >> $GITHUB_OUTPUT
 else
-  echo "::set-output name=state::unchanged"
+  echo "state=unchanged" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
消除 depends table actions 的警告


The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
