### PR TITLE
net-im/tencent-qq: add missing dependencies

### DIFF
--- a/net-im/tencent-qq/tencent-qq-3.2.9_p240617.ebuild
+++ b/net-im/tencent-qq/tencent-qq-3.2.9_p240617.ebuild
@@ -37,6 +37,8 @@ RDEPEND="
 	dev-libs/nss
 	appindicator? ( dev-libs/libayatana-appindicator )
 	x11-libs/libXScrnSaver
+	x11-libs/libXcomposite
+	x11-libs/libXdamage
 	x11-libs/libXtst
 	x11-misc/xdg-utils
 	app-accessibility/at-spi2-core:2


### PR DESCRIPTION
It seems that we missed the dependencies on `libXcomposite` and `libXdamage`.

```plain
# ldd /opt/QQ/qq
	linux-vdso.so.1 (0x00007ffdae5d0000)
	libffmpeg.so => /opt/QQ/libffmpeg.so (0x00007f50d0600000)
	libdl.so.2 => /usr/lib64/libdl.so.2 (0x00007f50db561000)
	libpthread.so.0 => /usr/lib64/libpthread.so.0 (0x00007f50db55c000)
	libglib-2.0.so.0 => /usr/lib64/libglib-2.0.so.0 (0x00007f50d0460000)
	libgobject-2.0.so.0 => /usr/lib64/libgobject-2.0.so.0 (0x00007f50db4f2000)
	libgio-2.0.so.0 => /usr/lib64/libgio-2.0.so.0 (0x00007f50d0200000)
	libnss3.so => /usr/lib64/libnss3.so (0x00007f50d00c4000)
	libnssutil3.so => /usr/lib64/libnssutil3.so (0x00007f50d0dcf000)
	libsmime3.so => /usr/lib64/libsmime3.so (0x00007f50d0da4000)
	libnspr4.so => /usr/lib64/libnspr4.so (0x00007f50d0d64000)
	libdbus-1.so.3 => /usr/lib64/libdbus-1.so.3 (0x00007f50d0061000)
	libatk-1.0.so.0 => /usr/lib64/libatk-1.0.so.0 (0x00007f50d0431000)
	libatk-bridge-2.0.so.0 => /usr/lib64/libatk-bridge-2.0.so.0 (0x00007f50d001d000)
	libcups.so.2 => /usr/lib64/libcups.so.2 (0x00007f50cff6b000)
	libgtk-3.so.0 => /usr/lib64/libgtk-3.so.0 (0x00007f50cf600000)
	libpango-1.0.so.0 => /usr/lib64/libpango-1.0.so.0 (0x00007f50cf587000)
	libcairo.so.2 => /usr/lib64/libcairo.so.2 (0x00007f50cf44a000)
	libX11.so.6 => /usr/lib64/libX11.so.6 (0x00007f50cf2d9000)
	libXcomposite.so.1 => /usr/lib64/libXcomposite.so.1 (0x00007f50db4e7000)
	libXdamage.so.1 => /usr/lib64/libXdamage.so.1 (0x00007f50db4e2000)
	libXext.so.6 => /usr/lib64/libXext.so.6 (0x00007f50d0418000)
	libXfixes.so.3 => /usr/lib64/libXfixes.so.3 (0x00007f50d0d5c000)
	libXrandr.so.2 => /usr/lib64/libXrandr.so.2 (0x00007f50d0d4f000)
	libgbm.so.1 => /usr/lib64/libgbm.so.1 (0x00007f50cff59000)
	libdrm.so.2 => /usr/lib64/libdrm.so.2 (0x00007f50cff3e000)
	libexpat.so.1 => /usr/lib64/libexpat.so.1 (0x00007f50cff11000)
	libxcb.so.1 => /usr/lib64/libxcb.so.1 (0x00007f50cf2ab000)
	libxkbcommon.so.0 => /usr/lib64/libxkbcommon.so.0 (0x00007f50cf25d000)
	libasound.so.2 => /usr/lib64/libasound.so.2 (0x00007f50cf16b000)
	libatspi.so.0 => /usr/lib64/libatspi.so.0 (0x00007f50cf135000)
	libm.so.6 => /usr/lib64/libm.so.6 (0x00007f50cf082000)
	libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/13/libgcc_s.so.1 (0x00007f50cf058000)
	libc.so.6 => /usr/lib64/libc.so.6 (0x00007f50cee68000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f50db583000)
	libpcre2-8.so.0 => /usr/lib64/libpcre2-8.so.0 (0x00007f50cedaa000)
	libffi.so.8 => /usr/lib64/libffi.so.8 (0x00007f50cff04000)
	libgmodule-2.0.so.0 => /usr/lib64/libgmodule-2.0.so.0 (0x00007f50d0412000)
	libz.so.1 => /usr/lib64/libz.so.1 (0x00007f50ced8d000)
	libmount.so.1 => /usr/lib64/libmount.so.1 (0x00007f50ced39000)
	libplc4.so => /usr/lib64/libplc4.so (0x00007f50ced31000)
	libplds4.so => /usr/lib64/libplds4.so (0x00007f50ced2b000)
	libgnutls.so.30 => /usr/lib64/libgnutls.so.30 (0x00007f50cea00000)
	libgdk-3.so.0 => /usr/lib64/libgdk-3.so.0 (0x00007f50cec76000)
	libpangocairo-1.0.so.0 => /usr/lib64/libpangocairo-1.0.so.0 (0x00007f50cec65000)
	libharfbuzz.so.0 => /usr/lib64/libharfbuzz.so.0 (0x00007f50ce8b8000)
	libpangoft2-1.0.so.0 => /usr/lib64/libpangoft2-1.0.so.0 (0x00007f50cec49000)
	libfontconfig.so.1 => /usr/lib64/libfontconfig.so.1 (0x00007f50ce858000)
	libfribidi.so.0 => /usr/lib64/libfribidi.so.0 (0x00007f50ce834000)
	libcairo-gobject.so.2 => /usr/lib64/libcairo-gobject.so.2 (0x00007f50cec3e000)
	libgdk_pixbuf-2.0.so.0 => /usr/lib64/libgdk_pixbuf-2.0.so.0 (0x00007f50ce801000)
	libepoxy.so.0 => /usr/lib64/libepoxy.so.0 (0x00007f50ce6fb000)
	libwayland-client.so.0 => /usr/lib64/libwayland-client.so.0 (0x00007f50ce6eb000)
	libpng16.so.16 => /usr/lib64/libpng16.so.16 (0x00007f50ce69e000)
	libfreetype.so.6 => /usr/lib64/libfreetype.so.6 (0x00007f50ce5b1000)
	libpixman-1.so.0 => /usr/lib64/libpixman-1.so.0 (0x00007f50ce4e6000)
	libXrender.so.1 => /usr/lib64/libXrender.so.1 (0x00007f50ce4d9000)
	libwayland-server.so.0 => /usr/lib64/libwayland-server.so.0 (0x00007f50ce4c4000)
	libXau.so.6 => /usr/lib64/libXau.so.6 (0x00007f50ce4bd000)
	libXdmcp.so.6 => /usr/lib64/libXdmcp.so.6 (0x00007f50ce4b5000)
	libblkid.so.1 => /usr/lib64/libblkid.so.1 (0x00007f50ce472000)
	libidn2.so.0 => /usr/lib64/libidn2.so.0 (0x00007f50ce450000)
	libunistring.so.5 => /usr/lib64/libunistring.so.5 (0x00007f50ce299000)
	libtasn1.so.6 => /usr/lib64/libtasn1.so.6 (0x00007f50ce27d000)
	libnettle.so.8 => /usr/lib64/libnettle.so.8 (0x00007f50ce211000)
	libhogweed.so.6 => /usr/lib64/libhogweed.so.6 (0x00007f50ce1ba000)
	libgmp.so.10 => /usr/lib64/libgmp.so.10 (0x00007f50ce10c000)
	libwayland-cursor.so.0 => /usr/lib64/libwayland-cursor.so.0 (0x00007f50ce102000)
	libwayland-egl.so.1 => /usr/lib64/libwayland-egl.so.1 (0x00007f50ce0fe000)
	libgraphite2.so.3 => /usr/lib64/libgraphite2.so.3 (0x00007f50ce0d6000)
	libjpeg.so.62 => /usr/lib64/libjpeg.so.62 (0x00007f50cdfe3000)
	libbz2.so.1 => /usr/lib64/libbz2.so.1 (0x00007f50cdfca000)
	libbrotlidec.so.1 => /usr/lib64/libbrotlidec.so.1 (0x00007f50cdfba000)
	libbrotlicommon.so.1 => /usr/lib64/libbrotlicommon.so.1 (0x00007f50cdf94000)
```