### PR TITLE
net-proxy/mihomo: add caps use flag for openrc

### DIFF
--- a/net-proxy/mihomo/metadata.xml
+++ b/net-proxy/mihomo/metadata.xml
@@ -7,7 +7,9 @@ pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 		<email>ston.jia@qq.com</email>
 	</maintainer>
 	<use>
-		<flag name="gvisor">enable TUN stack support for gvisor</flag>
+		<flag name="gvisor">Enable TUN stack support for gvisor</flag>
+		<flag name="systemd">Enable systemd support</flag>
+		<flag name="caps">Enable caps support for sys-apps/openrc</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">MetaCubeX/mihomo</remote-id>

--- a/net-proxy/mihomo/mihomo-1.18.6-r1.ebuild
+++ b/net-proxy/mihomo/mihomo-1.18.6-r1.ebuild
@@ -20,13 +20,26 @@ DEPEND="
 	acct-group/mihomo
 	acct-user/mihomo
 "
-RDEPEND="${DEPEND}"
+RDEPEND="
+	${DEPEND}
+	systemd? (
+		sys-apps/systemd
+	)
+	!systemd? (
+		caps? (
+			sys-apps/openrc[caps(+)]
+		)
+		!caps? (
+			sys-apps/openrc
+		)
+	)
+"
 BDEPEND=">=dev-lang/go-1.20.4"
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
-IUSE="+gvisor"
+IUSE="+gvisor systemd caps"
 
 src_compile() {
 	local BUILDTIME=$(LC_ALL=C date -u || die)


### PR DESCRIPTION
Flag caps only support openrc.

since sys-apps/openrc-0.54, we have to flag openrc +caps for initd capabilities https://bugs.gentoo.org/932090