### PR TITLE
Clean eapi6

### DIFF
--- a/net-misc/prips/prips-1.0.0.ebuild
+++ b/net-misc/prips/prips-1.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="print the IP addresses in a range"
 HOMEPAGE="http://devel.ringlet.net/sysutils/prips/"

--- a/x11-misc/i3lock-color/i3lock-color-9999.ebuild
+++ b/x11-misc/i3lock-color/i3lock-color-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit git-r3 autotools
 

--- a/x11-misc/i3lock-fancy/i3lock-fancy-9999.ebuild
+++ b/x11-misc/i3lock-fancy/i3lock-fancy-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit git-r3
 


### PR DESCRIPTION
x11-misc/i3lock-color-9999 inhert 的 git-r3.eclass  已经移除了 EAPI6 支持，https://github.com/gentoo/gentoo/commit/e27f68c1a16993efd00c81145d33d792a0f870d9 ，需要更新到 8
顺便把另外两个还在用 EAPI 6 的也更新到了8
```
ERROR: x11-misc/i3lock-color-9999::gentoo-zh failed (depend phase):
 *   git-r3: EAPI 6 not supported
```