### PR TITLE
app-emulation/la-ow-syscall: revbump

### DIFF
--- a/app-emulation/la-ow-syscall/la-ow-syscall-0.1.0-r1.ebuild
+++ b/app-emulation/la-ow-syscall/la-ow-syscall-0.1.0-r1.ebuild
@@ -36,6 +36,10 @@ KPROBES
 "
 
 src_compile() {
+	# otherwise the build script uses `uname -r` that will break if the
+	# target kernel version differs from the running one
+	export KVER="${KV_FULL}"
+
 	local modlist=(
 		la_ow_syscall
 	)
@@ -50,6 +54,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	linux-mod-r1_pkg_postinst
+
 	elog "Be sure to load the kernel module before running any old-world program:"
 	elog
 	elog "# modprobe la_ow_syscall"


### PR DESCRIPTION
* fix build when the target kernel version differs from the running one
* fix missing depmod in overridden pkg_postinst