### PR TITLE
metadata: add pkgcheck.conf

### DIFF
--- a/metadata/pkgcheck.conf
+++ b/metadata/pkgcheck.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+# Disable noisy keywords (checks)
+keywords = -PotentialStable,-RedundantVersion


### PR DESCRIPTION
https://wiki.gentoo.org/wiki/Pkgcheck#Configuration
https://pkgcore.github.io/pkgcheck/man/pkgcheck.html#config-file-support
pkgcheck 现在可以在 overlay  的  metadata/pkgcheck.conf 中配置，此次提交会让 pkgcheck scan 减少一些不重要的输出
我想这次提交和  #3926 也有关联
