### PR TITLE
README.md: add distfiles mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,18 @@ https://github.com/microcai/gentoo-zh/blob/deps-table/relation.md
 
   But please don't abuse this exception. It must be a pure font package.
 
-  # See wiki for some package not working
+# Distfiles mirror
+
+We provide a distfiles mirror that caches the distfiles in gentoo-zh.
+
+Our server, hosted on Finland:
+```
+GENTOO_MIRRORS="${GENTOO_MIRRORS} https://distfiles.gentoocn.org"
+```
+
+Nanjing University mirror:
+```
+GENTOO_MIRRORS="${GENTOO_MIRRORS} https://mirror.nju.edu.cn/gentoo-zh"
+```
+
+# See wiki for some package not working


### PR DESCRIPTION
添加了 distfiles mirror 主服务器和 NJU mirror 的描述， nju mirror 依赖 issue https://github.com/nju-lug/NJU-Mirror-Issue/issues/50 ，等 https://mirror.nju.edu.cn/gentoo-zh/distfiles 可以访问以后再合并这个 PR

Close: https://github.com/microcai/gentoo-zh/issues/5038
Close: https://github.com/microcai/gentoo-zh/issues/5039