### PR TITLE
fix failure of net-im/wemeet to start when the language setting is no…

### DIFF
--- a/net-im/wemeet/files/wemeetapp-1.sh
+++ b/net-im/wemeet/files/wemeetapp-1.sh
@@ -10,7 +10,7 @@ unset WAYLAND_DISPLAY
 # 解决非zh或en的语言设置闪退的问题
 # if "^zh" is not detected in $LANG $LC_ALL $LANGUAGE, set language to en_GB, else zh_CN
 if test "${LANG:0:2}" != "zh" -a "${LC_ALL:0:2}" != "zh" -a "${LANGUAGE:0:2}" != "zh"; then
-	export LC_ALL="en_GB.UTF-8"
+	export LC_ALL="en_US.UTF-8"
 else
 	export LC_ALL="zh_CN.UTF-8"
 fi

--- a/net-im/wemeet/files/wemeetapp-1.sh
+++ b/net-im/wemeet/files/wemeetapp-1.sh
@@ -7,6 +7,13 @@ export IBUS_USE_PORTAL=1 # fix ibus
 FONTCONFIG_DIR=$HOME/.config/fontconfig
 unset WAYLAND_DISPLAY
 
+# if "^zh" is not detected in $LANG $LC_ALL $LANGUAGE
+if test "${LANG:0:2}" != "zh" -a "${LC_ALL:0:2}" != "zh" -a "${LANGUAGE:0:2}" != "zh"; then
+	export LC_ALL="en_GB.UTF-8"; # 解决非zh或en的语言设置闪退的问题
+else
+	export LC_ALL="zh_CN.UTF-8"; # 解决非zh或en的语言设置闪退的问题
+fi;
+
 # if pipewire-pulse installed
 if [ -f /usr/bin/pipewire-pulse ]; then
 	export PULSE_LATENCY_MSEC=20 # 解决Pipewire播放声音卡顿的问题

--- a/net-im/wemeet/files/wemeetapp-1.sh
+++ b/net-im/wemeet/files/wemeetapp-1.sh
@@ -7,12 +7,13 @@ export IBUS_USE_PORTAL=1 # fix ibus
 FONTCONFIG_DIR=$HOME/.config/fontconfig
 unset WAYLAND_DISPLAY
 
-# if "^zh" is not detected in $LANG $LC_ALL $LANGUAGE
+# 解决非zh或en的语言设置闪退的问题
+# if "^zh" is not detected in $LANG $LC_ALL $LANGUAGE, set language to en_GB, else zh_CN
 if test "${LANG:0:2}" != "zh" -a "${LC_ALL:0:2}" != "zh" -a "${LANGUAGE:0:2}" != "zh"; then
-	export LC_ALL="en_GB.UTF-8"; # 解决非zh或en的语言设置闪退的问题
+	export LC_ALL="en_GB.UTF-8"
 else
-	export LC_ALL="zh_CN.UTF-8"; # 解决非zh或en的语言设置闪退的问题
-fi;
+	export LC_ALL="zh_CN.UTF-8"
+fi
 
 # if pipewire-pulse installed
 if [ -f /usr/bin/pipewire-pulse ]; then


### PR DESCRIPTION
…t "zh" or "en"
解决了当语言设置部位zh或en的时候，例如LANG="fr_FR.UTF-8"的情况下无法启动的问题，方法是通过检测 : 若环境变量LANG LC_ALL LANGUAGE设置不包含"^zh"则将LC_ALL设置为en_GB.UTF-8，否则设置为zh_CH.UTF-8