### PR TITLE
net-misc/rustdesk: update SRC_URI

### DIFF
--- a/net-misc/rustdesk/rustdesk-1.2.6.ebuild
+++ b/net-misc/rustdesk/rustdesk-1.2.6.ebuild
@@ -792,7 +792,7 @@ SRC_URI="
 	https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so
 		-> ${P}-libsciter-gtk.so
 
-	mirror+${CARGO_CRATE_URIS}
+	${CARGO_CRATE_URIS}
 "
 
 LICENSE="AGPL-3"


### PR DESCRIPTION
`${CARGO_CRATE_URIS}` `${NUGET_URIS}`  之类的 URIS，即使前边加了 `mirror+` 也并不会 mirror distfiles