### PR TITLE
sys-boot/ventoy-bin-1.0.99: Add runtime qt5 dependencies

### DIFF
--- a/sys-boot/ventoy-bin/ventoy-bin-1.0.99.ebuild
+++ b/sys-boot/ventoy-bin/ventoy-bin-1.0.99.ebuild
@@ -21,7 +21,12 @@ DEPEND="
 	sys-fs/exfat-utils
 	sys-block/parted
 "
-RDEPEND="${DEPEND}"
+RDEPEND="
+	${DEPEND}
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
 
 CARCH="x86_64"
 


### PR DESCRIPTION
Fixes #5205 