### PR TITLE
sys-boot/ventoy-bin: qt5 and gtk USE flags

### DIFF
--- a/sys-boot/ventoy-bin/ventoy-bin-1.0.99.ebuild
+++ b/sys-boot/ventoy-bin/ventoy-bin-1.0.99.ebuild
@@ -14,6 +14,8 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
 
+IUSE="+qt5 +gtk"
+
 RESTRICT="strip mirror"
 
 DEPEND="
@@ -23,9 +25,8 @@ DEPEND="
 "
 RDEPEND="
 	${DEPEND}
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	qt5? ( dev-qt/qtcore:5 dev-qt/qtgui:5 dev-qt/qtwidgets:5 )
+	gtk? ( x11-libs/gtk+:3 )
 "
 
 CARCH="x86_64"
@@ -56,6 +57,15 @@ src_prepare() {
 	for binary in xzcat hexdump; do
 		rm -fv tool/$CARCH/$binary || die
 	done
+
+	# Exclude optional GUI binaries
+	if ! use qt5; then
+		rm -fv tool/$CARH/Ventoy2Disk.qt5
+	fi
+	if ! use gtk; then
+		rm -fv tool/$CARH/Ventoy2Disk.gtk3
+	fi
+
 	default
 }
 


### PR DESCRIPTION
These new flags are enabled by default, and they enable installation of Ventoy2Disk.{qt5,gtk3} (or rather, disable removal of), which depend on runtime libraries for qt and gtk, which are also added to RDEPEND with these use flags. This enables users to opt out of including these executables and their runtime dependencies.