### PR TITLE
net-proxy/clash-verge-bin: update symlink for verge-mihomo binary

### DIFF
--- a/net-proxy/clash-verge-bin/clash-verge-bin-1.7.7-r1.ebuild
+++ b/net-proxy/clash-verge-bin/clash-verge-bin-1.7.7-r1.ebuild
@@ -30,6 +30,7 @@ src_install(){
 	dobin "${S}"/usr/bin/clash-verge
 	insinto /usr/lib/clash-verge
 	doins -r "${S}"/usr/lib/clash-verge/resources
+	dosym -r "/usr/bin/mihomo" "/usr/bin/verge-mihomo"
 	domenu usr/share/applications/clash-verge.desktop
 	doicon -s 128 usr/share/icons/hicolor/128x128/apps/${PN/-bin}.png
 	doicon -s 256 usr/share/icons/hicolor/256x256@2/apps/${PN/-bin}.png


### PR DESCRIPTION
close #5310

搜了一下，1.7开始才改了这个的 https://github.com/clash-verge-rev/clash-verge-rev/commit/e6e2b1f142e8acdfd442b5b0438410625471fd86