### PR TITLE
net-misc/rustdesk: fix dependency, add missing die

### DIFF
--- a/net-misc/rustdesk/rustdesk-1.3.0.ebuild
+++ b/net-misc/rustdesk/rustdesk-1.3.0.ebuild
@@ -837,7 +837,7 @@ RDEPEND="
 	x11-libs/libXfixes
 	media-libs/libpulse
 	x11-misc/xdotool
-	media-libs/libva
+	media-libs/libva[X]
 	wayland? ( media-video/pipewire[gstreamer] )
 	hwaccel? ( x11-libs/libvdpau )
 "
@@ -863,11 +863,11 @@ src_prepare() {
 	PATCHES+=(
 		"${FILESDIR}"/rust-sciter.patch
 	)
-	cd "${S}"/..
+	cd "${S}"/.. || die
 
 	default
 
-	cd -
+	cd - || die
 	cd ../rust-webm-*/src/sys || die
 	rm -rf libwebm/ || die
 	ln -s "${WORKDIR}"/libwebm-libwebm-*/ libwebm || die


### PR DESCRIPTION
Hi,

I was trying to install `rustdesk` on a vm but it always failed because of a missing dependency.
I've updated the ebuild and also added some missing `die`'s. Since it's a build fix and only minor changes i didn't do a rev-bump. Hope thats fine.

Regards
Michael