### PR TITLE
www-servers/miniserve: fix nvchecker

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1117,6 +1117,7 @@ github_account = "peeweep"
 source = "github"
 github = "svenstaro/miniserve"
 use_latest_release = true
+prefix = "v"
 github_account = "peeweep"
 
 # only live package in gentoo-zh


### PR DESCRIPTION
Close: https://github.com/microcai/gentoo-zh/issues/5402