### PR TITLE
net-proxy/dae: use git ver as dae's cmd version when 9999

### DIFF
--- a/net-proxy/dae/dae-9999.ebuild
+++ b/net-proxy/dae/dae-9999.ebuild
@@ -51,7 +51,8 @@ src_compile() {
 	filter-flags "-march=*" "-mtune=*"
 	append-cflags "-fno-stack-protector"
 
-	emake VERSION="${PV}" GOFLAGS="-buildvcs=false"
+	local GIT_VER=$(git describe --tags --long | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-\([^-]*\)-\([^-]*\)$/.\1.\2/;s/-//')
+	emake VERSION="${GIT_VER}" GOFLAGS="-buildvcs=false"
 }
 
 src_install() {


### PR DESCRIPTION
before:

```
dae version 9999
go runtime go1.23.1 linux/amd64
Copyright (c) 2022-2024 @daeuniverse
License GNU AGPLv3 <https://github.com/daeuniverse/dae/blob/main/LICENSE>
```

after:

```
dae version 0.8.0.r4.g0e1301b
go runtime go1.23.1 linux/amd64
Copyright (c) 2022-2024 @daeuniverse
License GNU AGPLv3 <https://github.com/daeuniverse/dae/blob/main/LICENSE>
```