### PR TITLE
.github/workflows: nvchecker: remove sed old_ver.json

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -39,7 +39,7 @@ jobs:
         echo "$pkgs"
         pkgs="{ ${pkgs::-1} }"
         echo "$pkgs" > .github/workflows/old_ver.json
-        sed -r -i 's/_p[^"]*//' .github/workflows/old_ver.json
+        # sed -r -i 's/_p[^"]*//' .github/workflows/old_ver.json
         cat .github/workflows/old_ver.json
         echo "::endgroup::"
 


### PR DESCRIPTION
之前因为 #2927 删掉了  _p ，不该删，是 app-i18n/zh-autoconvert 的 nvchecker 写的有问题