### PR TITLE
media-sound/netease-cloud-music-gtk: adjust inherit order

### DIFF
--- a/media-sound/netease-cloud-music-gtk/netease-cloud-music-gtk-2.5.0.ebuild
+++ b/media-sound/netease-cloud-music-gtk/netease-cloud-music-gtk-2.5.0.ebuild
@@ -330,7 +330,7 @@ declare -A GIT_CRATES=(
 	[netease-cloud-music-api]="https://github.com/gmg137/netease-cloud-music-api;${NCM_API_COMMIT};netease-cloud-music-api-%commit%"
 )
 
-inherit cargo gnome2-utils meson optfeature xdg flag-o-matic
+inherit gnome2-utils meson optfeature xdg cargo
 
 DESCRIPTION="netease cloud music player based on Rust & GTK for Linux"
 HOMEPAGE="https://github.com/gmg137/netease-cloud-music-gtk"
@@ -390,7 +390,6 @@ src_prepare() {
 }
 
 src_configure() {
-	filter-lto
 	local emesonargs=(
 		-Dlocaledir=share/locale
 		-Ddatadir=share


### PR DESCRIPTION
turns out filter-lto isn't necessary. you just have to inherit cargo after meson.