### PR TITLE
media-sound/netease-cloud-music-gtk: make isahc use system curl

### DIFF
--- a/media-sound/netease-cloud-music-gtk/files/isahc-disable-static-curl.patch
+++ b/media-sound/netease-cloud-music-gtk/files/isahc-disable-static-curl.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 27f8d74..491fac0 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -6,7 +6,7 @@ edition = "2021"
+ # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+ 
+ [dependencies]
+-isahc = { version = "^1", features = ["cookies"] }
++isahc = { version = "^1", default-features = false, features = ["cookies", "http2", "text-decoding"] }
+ lazy_static = "*"
+ regex = "*"
+ urlqstring = "*"

--- a/media-sound/netease-cloud-music-gtk/netease-cloud-music-gtk-2.5.0.ebuild
+++ b/media-sound/netease-cloud-music-gtk/netease-cloud-music-gtk-2.5.0.ebuild
@@ -386,6 +386,10 @@ src_prepare() {
 
 	sed -i -E "s#${ncm_api_git}#${ncm_api_path}#g" "${S}/Cargo.toml" || die "ncm-api workaround failed"
 
+	pushd "${WORKDIR}/netease-cloud-music-api-${NCM_API_COMMIT}" > /dev/null || die
+	eapply "${FILESDIR}/isahc-disable-static-curl.patch"
+	popd > /dev/null || die
+
 	default
 }
 


### PR DESCRIPTION
isahc use static-curl by default, this violates gentoo policy and causes issues with libressl.