### PR TITLE
net-im/tencent-qq: fix flag, default non bwrap

### DIFF
--- a/net-im/tencent-qq/files/qq.sh
+++ b/net-im/tencent-qq/files/qq.sh
@@ -2,11 +2,16 @@
 
 if [ -d ~/.config/QQ/versions ]; then
 	find ~/.config/QQ/versions -name sharp-lib -type d -exec rm -r {} \; 2>/dev/null
+	find ~/.config/QQ/versions -name libssh2.so.1 -type f -exec rm {} \; 2>/dev/null
 fi
 
-# Allow users to override command-line options
-if [[ -f $XDG_CONFIG_HOME/qq-flags.conf ]]; then
-    QQ_USER_FLAGS="$(grep -v '^#' $XDG_CONFIG_HOME/qq-flags.conf)"
+rm -rf ~/.config/QQ/crash_files/*
+
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+
+if [[ -f "${XDG_CONFIG_HOME}/qq-flags.conf" ]]; then
+	mapfile -t QQ_USER_FLAGS <<<"$(grep -v '^#' "${XDG_CONFIG_HOME}/qq-flags.conf")"
+	echo "User flags:" ${QQ_USER_FLAGS[@]}
 fi
 
-exec /opt/QQ/qq $QQ_USER_FLAGS "$@"
+exec /opt/QQ/qq ${QQ_USER_FLAGS[@]} "$@"

--- a/net-im/tencent-qq/files/start.sh
+++ b/net-im/tencent-qq/files/start.sh
@@ -43,7 +43,7 @@ fi
 # 从 flags 文件中加载参数
 
 set -euo pipefail
-flags_file="${XDG_CONFIG_HOME}/qq-electron-flags.conf"
+flags_file="${XDG_CONFIG_HOME}/qq-flags.conf"
 declare -a flags
 
 if [[ -f "${flags_file}" ]]; then

--- a/net-im/tencent-qq/tencent-qq-3.2.15_p241224-r2.ebuild
+++ b/net-im/tencent-qq/tencent-qq-3.2.15_p241224-r2.ebuild
@@ -30,7 +30,7 @@ LICENSE="Tencent"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm64"
 
-IUSE="+bwrap system-vips gnome liteloader"
+IUSE="bwrap system-vips gnome liteloader"
 
 RESTRICT="strip mirror"
 
@@ -80,6 +80,9 @@ src_install() {
 		unpacker "${DISTDIR}/${_QQFileName}_${MY_PV}_${ARCH}${_ArchExt}${_QQFileSuffix}"
 	fi
 
+	# Fix KDK Wayland QQ icons
+	mv "${D}/usr/share/applications/qq.desktop" "${D}/usr/share/applications/QQ.desktop" || die
+
 	if use system-vips; then
 		rm -r "${D}"/opt/QQ/resources/app/sharp-lib || die
 	fi
@@ -87,7 +90,7 @@ src_install() {
 	if use bwrap; then
 		exeinto /opt/QQ
 		doexe "${FILESDIR}"/start.sh
-		sed -i 's!/opt/QQ/qq!/opt/QQ/start.sh!' "${D}"/usr/share/applications/qq.desktop || die
+		sed -i 's!/opt/QQ/qq!/opt/QQ/start.sh!' "${D}"/usr/share/applications/QQ.desktop || die
 		insinto /opt/QQ/workarounds
 		doins "${FILESDIR}"/{config.json,xdg-open.sh,vercmp.sh}
 		fperms +x /opt/QQ/workarounds/{xdg-open.sh,vercmp.sh}
@@ -102,18 +105,16 @@ src_install() {
 			"${D}"/opt/QQ/start.sh || die
 
 	else
-		sed -i 's!/opt/QQ/qq!/usr/bin/qq!' "${D}"/usr/share/applications/qq.desktop || die
+		sed -i 's!/opt/QQ/qq!/usr/bin/qq!' "${D}"/usr/share/applications/QQ.desktop || die
 	fi
 
 	if use bwrap; then
 		dosym -r /opt/QQ/start.sh /usr/bin/qq
-	elif use system-vips; then
-		newbin "$FILESDIR/qq.sh" qq
 	else
-		dosym -r /opt/QQ/qq /usr/bin/qq
+		newbin "$FILESDIR/qq.sh" qq
 	fi
 
-	sed -i 's!/usr/share/icons/hicolor/512x512/apps/qq.png!qq!' "${D}"/usr/share/applications/qq.desktop || die
+	sed -i 's!/usr/share/icons/hicolor/512x512/apps/qq.png!qq!' "${D}"/usr/share/applications/QQ.desktop || die
 	gzip -d "${D}"/usr/share/doc/linuxqq/changelog.gz || die
 	dodoc "${D}"/usr/share/doc/linuxqq/changelog
 	rm -rf "${D}"/usr/share/doc/linuxqq/ || die


### PR DESCRIPTION
经过测试，现在的qq就算不套bwrap也能正常用（除了在kde下按截图按钮会闪退）
同时默认情况下关闭bwrap, 因为这个包名叫tencent-qq, 我觉得不要帮用户 做选择比较好
`qq-electron-flags.conf` 将改为 `qq-flags.conf`, 因为 gentoo 中 QQ 没有使用系统的electron
修复了在 KDE wayland 下 alt+tab 界面显示 QQ 图标不正常的问题