### PR TITLE
net-proxy/dae: not install unusable config.dae

### DIFF
--- a/net-proxy/dae/dae-0.9.0.ebuild
+++ b/net-proxy/dae/dae-0.9.0.ebuild
@@ -79,9 +79,9 @@ src_install() {
 	systemd_dounit install/dae.service
 	newinitd "${FILESDIR}"/dae.initd dae
 
-	insinto /etc/dae
+	keepdir /etc/dae/
+	insinto /usr/share/dae
 	newins example.dae config.dae.example
-	newins install/empty.dae config.dae
 
 	newbashcomp install/shell-completion/dae.bash dae
 	newfishcomp install/shell-completion/dae.fish dae.fish

--- a/net-proxy/dae/dae-9999.ebuild
+++ b/net-proxy/dae/dae-9999.ebuild
@@ -61,9 +61,9 @@ src_install() {
 	systemd_dounit install/dae.service
 	newinitd "${FILESDIR}"/dae.initd dae
 
-	insinto /etc/dae
+	keepdir /etc/dae/
+	insinto /usr/share/dae
 	newins example.dae config.dae.example
-	newins install/empty.dae config.dae
 
 	newbashcomp install/shell-completion/dae.bash dae
 	newfishcomp install/shell-completion/dae.fish dae.fish


### PR DESCRIPTION
将 `example.dae` 安装到 `/usr/share/dae/`让用户自己拷贝中即可