### PR TITLE
app-editors/cursor: fix the issue where the taskbar icon appears as a large W under Wayland

### DIFF
--- a/app-editors/cursor/cursor-0.44.11-r1.ebuild
+++ b/app-editors/cursor/cursor-0.44.11-r1.ebuild
@@ -87,9 +87,9 @@ src_install() {
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )
 	fi
 
-	sed -i -e "s|^Exec=.*|Exec=cursor ${EXEC_EXTRA_FLAGS[*]} %U|" \
-		usr/share/applications/cursor.desktop || die
-	domenu usr/share/applications/cursor.desktop
+	sed "s|^Exec=.*|Exec=cursor ${EXEC_EXTRA_FLAGS[*]} %U|" \
+		usr/share/applications/cursor.desktop > cursor-url-handler.desktop || die
+	domenu cursor-url-handler.desktop
 
 	insinto /usr/share
 	doins -r usr/share/icons

--- a/app-editors/cursor/cursor-0.45.8-r1.ebuild
+++ b/app-editors/cursor/cursor-0.45.8-r1.ebuild
@@ -87,9 +87,9 @@ src_install() {
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )
 	fi
 
-	sed -i -e "s|^Exec=.*|Exec=cursor ${EXEC_EXTRA_FLAGS[*]} %U|" \
-		usr/share/applications/cursor.desktop || die
-	domenu usr/share/applications/cursor.desktop
+	sed "s|^Exec=.*|Exec=cursor ${EXEC_EXTRA_FLAGS[*]} %U|" \
+		usr/share/applications/cursor.desktop > cursor-url-handler.desktop || die
+	domenu cursor-url-handler.desktop
 
 	insinto /usr/share
 	doins -r usr/share/icons


### PR DESCRIPTION
The key issue here is that the window class of cusor is cursor-url-handler, while under Wayland, recognizing window icons requires the window class and desktop file name to be exactly the same.

BTW: renaming the desktop file does not affect its use under X11.