### PR TITLE
x11-terms/wezterm-bin: fix required openssl version

### DIFF
--- a/x11-terms/wezterm-bin/wezterm-bin-20240203.ebuild
+++ b/x11-terms/wezterm-bin/wezterm-bin-20240203.ebuild
@@ -25,7 +25,10 @@ REQUIRED_USE="|| ( wayland X )"
 RDEPEND="
 	sys-apps/dbus
 	>=media-libs/fontconfig-2.12
-	>=dev-libs/openssl-1.1
+	|| (
+			dev-libs/openssl-compat:1.1.1
+			dev-libs/openssl:0/1.1
+	)
 	wayland? (
 		dev-libs/wayland
 		dev-libs/wayland-protocols


### PR DESCRIPTION
@peeweep 
Close: #6248 