### PR TITLE
app-text/cajviewer: try to fix preserved libs warning due to dev-qt/qtvirtualkeyboard

### DIFF
--- a/app-text/cajviewer/cajviewer-9.0-r1.ebuild
+++ b/app-text/cajviewer/cajviewer-9.0-r1.ebuild
@@ -32,6 +32,9 @@ QA_PREBUILT="
 "
 
 src_install(){
+	# fix preserved libs warning due to dev-qt/qtvirtualkeyboard
+	rm -f "${S}"/opt/cajviewer/plugins/platforminputcontexts/libqtvirtualkeyboardplugin.so || die
+
 	insinto "/opt"
 	doins -r "./${MY_PREFIX}"
 


### PR DESCRIPTION
尝试修复因为`dev-qt/qtvirtualkeyboard`依赖移除造成的警告
```
!!! existing preserved libs:
>>> package: dev-qt/qtvirtualkeyboard-5.15.16
 *  - /usr/lib64/libQt5VirtualKeyboard.so.5
 *  - /usr/lib64/libQt5VirtualKeyboard.so.5.15.16
 *      used by /opt/cajviewer/plugins/platforminputcontexts/libqtvirtualkeyboardplugin.so (app-text/cajviewer-9.0-r1)
```
虽然有过分简单粗暴的嫌疑，但是似乎不影响程序正常运行，因此提交