### PR TITLE
media-libs/libsdl2: add steam user notice

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.32.50.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.32.50.ebuild
@@ -134,3 +134,10 @@ multilib_src_install_all() {
 	rm -r "${ED}"/usr/share/licenses/ || die
 	dodoc {BUGS,COMPATIBILITY,HOW_TO_TEST_GAMES}.md README.md
 }
+
+pkg_postinst() {
+	einfo "If you are using steam,"
+	einfo "Before launching,"
+	einfo "please set the LD_PRELOAD environment variable to"
+	einfo "${EPREFIX}/usr/$(ABI=x86 get_libdir)/libSDL3.so"
+}


### PR DESCRIPTION
在安装libsdl2-compat之后，无法启动steam的临时解决方案
在启动steam的时候设置环境变量LD_PRELOAD,指向系统的libSDL3.so