### PR TITLE
actions: nvchecker: fix issues search deprecated

### DIFF
--- a/.github/workflows/issues-bumper.js
+++ b/.github/workflows/issues-bumper.js
@@ -87,6 +87,7 @@ module.exports = async ({ github, context, core }) => {
           q: searchQuery,
           per_page: 100,
           page: page_number,
+          advanced_search: "true",
         });
         response = searchIssues.data.items;
 


### PR DESCRIPTION
we need set advanced_search explicitly.

[@octokit/request] "GET https://api.github.com/search/issues?q=repo%3Amicrocai%2Fgentoo-zh%20is%3Aissue%20label%3Anvchecker%20in%3Atitle%20%5Bnvchecker%5D%20app-crypt%2Farchlinux-keyring%20can%20be%20bump%20to%20&per_page=100&page=1" is deprecated. It is scheduled to be removed on Thu, 04 Sep 2025 00:00:00 GMT

https://github.com/octokit/request.js/issues/746