### PR TITLE
update libsdl2 libsdl3 slot

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.32.50.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.32.50.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/libsdl-org/sdl2-compat/releases/download/release-${P
 S="${WORKDIR}/sdl2-compat-${PV}"
 
 LICENSE="ZLIB"
-SLOT="2"
+SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 IUSE="alsa aqua dbus fcitx gles1 gles2 +haptic ibus jack +joystick kms libsamplerate nas opengl oss pipewire pulseaudio sndio +sound static-libs test udev +video vulkan wayland X xscreensaver"

--- a/media-libs/libsdl3/libsdl3-3.2.4.ebuild
+++ b/media-libs/libsdl3/libsdl3-3.2.4.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libsdl.org/"
 SRC_URI="https://github.com/libsdl-org/SDL/releases/download/release-${PV}/SDL3-${PV}.zip"
 
 LICENSE="ZLIB"
-SLOT="3"
+SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 IUSE="


### PR DESCRIPTION
libsdl2 libsdl3 以包名区分版本，而不是 slot。将 slot 改为 0，和 main tree 一致。

![图片](https://github.com/user-attachments/assets/6ad5847a-c698-4ba6-aef3-69a77fbfa006)

