### PR TITLE
.github/workflows: update cursor nvchecker regex

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -105,7 +105,7 @@ github_account = "Linerre"
 ["app-editors/cursor"]
 source = "regex"
 url = "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=latest"
-regex = 'Cursor-(\d+\.\d+\.\d+)'
+regex = '"version":"([\d.]+)"'
 github_account = "douglarek"
 
 ["app-editors/marktext-bin"]


### PR DESCRIPTION
```
{
  "downloadUrl": "https://downloads.cursor.com/production/client/linux/x64/appimage/Cursor-0.47.8-xxx.AppImage",
  "version": "0.47.8"
}
```