### PR TITLE
profiles: mask media-libs/libsdl2

### DIFF
--- a/.github/workflows/pkgcheck-checks-on-pr.yml
+++ b/.github/workflows/pkgcheck-checks-on-pr.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '.github/**'
       - 'metadata/**'
+      - 'profiles/**'
       - 'README.md'
       - '.gitignore'
     types: [opened, reopened, synchronize]

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -7,4 +7,4 @@
 >=net-proxy/clash-verge-bin-1.7.0
 
 # mask sdl2-compat, unmask it if you wants it
-=media-libs/libsdl2-2.30.51
+media-libs/libsdl2


### PR DESCRIPTION
looks like forgot edit package.mask when bump to 2.32.50 (c6a2a68c), remove the explicit version in package.mask.