### PR TITLE
README.md: `emerge --sync` replace to `emaint sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```
 eselect repository enable gentoo-zh
-emerge --sync
+emaint sync
 ```
 
 # rule no.1


### PR DESCRIPTION
From the man:

    NOTE: The emerge --sync command is a compatibility command. Sync operations are now performed using the new emaint sync module

See https://wiki.gentoo.org/wiki/Full_manpages/emerge