### PR TITLE
.github/workflows: nvchecker: remove label when searching

### DIFF
--- a/.github/workflows/issues-bumper.js
+++ b/.github/workflows/issues-bumper.js
@@ -85,7 +85,7 @@ module.exports = async ({ github, context, core }) => {
   `;
 
   const variables = {
-    searchQuery: `repo:${repoName} is:issue label:nvchecker in:title ${titlePrefix}`,
+    searchQuery: `repo:${repoName} is:issue in:title ${titlePrefix}`,
     cursor: null,
   };
 


### PR DESCRIPTION
用 graphql api 创建 issues 时无法同时添加 label ，所以搜索时也不应该搜索 label。
只是一个 workaround，很快会用新的 bot 代替