### PR TITLE
net-misc/apifox: update nvchecker

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1152,7 +1152,7 @@ github_account = "gouwazi"
 source = "regex"
 url = "https://api.apifox.com/api/v1/configs/client-updates/2/mac/latest-mac.yml"
 regex = 'version: (.*)'
-github_account = ["gouwazi", "peeweep"]
+github_account = ["gouwazi"]
 
 ["net-misc/baidunetdisk"]
 source = "regex"


### PR DESCRIPTION
我的家宽被 apifox 拉黑，无法再下载
```
% ebuild /var/db/repos/gentoo-zh/net-misc/apifox/apifox-2.7.8.ebuild fetch
>>> Downloading 'https://file-assets.apifox.com/download/Apifox-linux-latest.zip'
--2025-05-04 16:05:40--  https://file-assets.apifox.com/download/Apifox-linux-latest.zip
Resolving file-assets.apifox.com... xxx
Connecting to file-assets.apifox.com|xxx|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://black-list.apifox.com/page [following]
--2025-05-04 16:05:40--  https://black-list.apifox.com/page
Resolving black-list.apifox.com... 118.178.181.20, 121.199.72.199
Connecting to black-list.apifox.com|118.178.181.20|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1004 [text/html]
Saving to: ‘/var/cache/distfiles/apifox-2.7.8-amd64.zip.__download__’

/var/cache/distfiles/apifox-2.7.8-amd64.zip.__download__ 100%[===============================================================================================================================>]    1004  --.-KB/s    in 0s      

2025-05-04 16:05:40 (902 MB/s) - ‘/var/cache/distfiles/apifox-2.7.8-amd64.zip.__download__’ saved [1004/1004]

!!! Fetched file: apifox-2.7.8-amd64.zip VERIFY FAILED!
!!! Reason: Filesize does not match recorded size
!!! Got:      1004
!!! Expected: 283388122
Refetching... File renamed to '/var/cache/distfiles/apifox-2.7.8-amd64.zip._checksum_failure_.ho8ln43m'

!!! Couldn't download 'apifox-2.7.8-amd64.zip'. Aborting.
```