### PR TITLE
dev-util/mamba: add libfmt version constraint

### DIFF
--- a/dev-util/mamba/files/mamba-libfmt.patch
+++ b/dev-util/mamba/files/mamba-libfmt.patch
@@ -1,0 +1,34 @@
+diff --git a/libmambapy/src/libmambapy/bindings/utils.cpp b/libmambapy/src/libmambapy/bindings/utils.cpp
+index 1f5c3cc..45157bf 100644
+--- a/libmambapy/src/libmambapy/bindings/utils.cpp
++++ b/libmambapy/src/libmambapy/bindings/utils.cpp
+@@ -109,11 +109,11 @@ namespace mambapy
+                         return std::nullopt;
+                     }
+                     const auto fg = style.get_foreground();
+-                    if (fg.is_rgb)
++                    if (!fg.is_terminal_color())
+                     {
+-                        return { { fmt::rgb(fg.value.rgb_color) } };
++                        return { { fmt::rgb(fg.value()) } };
+                     }
+-                    return { { static_cast<fmt::terminal_color>(fg.value.term_color) } };
++                    return { { static_cast<fmt::terminal_color>(fg.value()) } };
+                 }
+             )
+             .def_property_readonly(
+@@ -125,11 +125,11 @@ namespace mambapy
+                         return std::nullopt;
+                     }
+                     const auto bg = style.get_background();
+-                    if (bg.is_rgb)
++                    if (!bg.is_terminal_color())
+                     {
+-                        return { { fmt::rgb(bg.value.rgb_color) } };
++                        return { { fmt::rgb(bg.value()) } };
+                     }
+-                    return { { static_cast<fmt::terminal_color>(bg.value.term_color) } };
++                    return { { static_cast<fmt::terminal_color>(bg.value()) } };
+                 }
+             )
+             .def_property_readonly(

--- a/dev-util/mamba/mamba-2.1.1.ebuild
+++ b/dev-util/mamba/mamba-2.1.1.ebuild
@@ -49,7 +49,7 @@ DEPEND="app-arch/libarchive:=
 		sys-fs/e2fsprogs
 		sys-libs/zlib
 		)
-	dev-libs/libfmt:=
+	<=dev-libs/libfmt-11.1
 	dev-libs/spdlog
 	net-misc/curl
 	python? ( ${PYTHON_DEPS} )


### PR DESCRIPTION
add libfmt version constraint and add a patch maybe useful when libfmt>11.1