### PR TITLE
app-editors/cursor: fix fcitx5 input when using wayland

### DIFF
--- a/app-editors/cursor/cursor-0.50.7.ebuild
+++ b/app-editors/cursor/cursor-0.50.7.ebuild
@@ -105,7 +105,7 @@ src_install() {
 
 	local EXEC_EXTRA_FLAGS=()
 	if use wayland; then
-		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" )
+		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" "--wayland-text-input-version=3" )
 	fi
 	if use egl; then
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )


### PR DESCRIPTION
Wayland requires matching text-input protocol versions between compositor and client. GNOME supports text-input-v3, but Chromium (used by cursor) defaults to v1. Add launch argument to specify version 3 explicitly:

--ozone-platform-hint=auto --enable-wayland-ime --wayland-text-input-version=3

This allows cursor to work with input methods under Wayland.