### PR TITLE
x11-themes:ori-fcitx5: new package

### DIFF
--- a/x11-themes/ori-fcitx5/metadata.xml
+++ b/x11-themes/ori-fcitx5/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>akira.uestc@gmail.com</email>
+		<name>Akira-uestc</name>
+	</maintainer>
+	<upstream>
+		<remote-id type='github'>Reverier-Xu/Ori-fcitx5</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/x11-themes/ori-fcitx5/ori-fcitx5-9999.ebuild
+++ b/x11-themes/ori-fcitx5/ori-fcitx5-9999.ebuild
@@ -1,0 +1,20 @@
+EAPI=8
+inherit git-r3
+
+DESCRIPTION="Ori theme for Fcitx5"
+HOMEPAGE="https://github.com/Reverier-Xu/Ori-fcitx5"
+EGIT_REPO_URI="https://github.com/Reverier-Xu/Ori-fcitx5.git"
+EGIT_BRANCH="master"
+
+LICENSE="MPL-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+
+RDEPEND="app-i18n/fcitx:5"
+DEPEND="${RDEPEND}"
+
+src_install() {
+	insinto /usr/share/fcitx5/themes/
+	doins -r "${S}"/OriLight
+	doins -r "${S}"/OriDark
+}


### PR DESCRIPTION
Add Ori-fcitx5, a rounded-corner theme for fcitx5. Installed to /usr/share/fcitx5/themes/