### PR TITLE
net-im/wechat: adjust USE flags and dependencies for fcitx/ibus

### DIFF
--- a/net-im/wechat/wechat-4.0.1.11-r2.ebuild
+++ b/net-im/wechat/wechat-4.0.1.11-r2.ebuild
@@ -18,8 +18,8 @@ LICENSE="all-rights-reserved"
 
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm64 ~loong"
-IUSE="+fcitx ibus"
-REQUIRED_USE="^^ ( fcitx ibus )"
+IUSE="fcitx ibus"
+REQUIRED_USE="?? ( fcitx ibus )"
 
 RESTRICT="strip mirror bindist"
 BDEPEND="
@@ -40,6 +40,8 @@ RDEPEND="
 	x11-libs/xcb-util-keysyms
 	x11-libs/xcb-util-renderutil
 	x11-libs/xcb-util-wm
+	fcitx? ( app-i18n/fcitx )
+	ibus? ( app-i18n/ibus )
 	loong? ( virtual/loong-ow-compat )
 "
 QA_PREBUILT="*"
@@ -86,4 +88,8 @@ src_install() {
 
 	insinto /usr/share
 	doins -r usr/share/icons
+}
+
+pkg_postinst() {
+	einfo "If you need to input Chinese in WeChat, please enable the corresponding USE flag (fcitx or ibus)."
 }


### PR DESCRIPTION
Considering that WeChat is an international software, we have reason not to enable fcitx or ibus by default, and only one of these can be enabled at a time. Additionally, if any are enabled, it should ensure runtime dependencies correspond to the input method.