### PR TITLE
net-proxy/clash-verge-bin: keyword 2.3.2 for ~amd64, ~arm64

### DIFF
--- a/net-proxy/clash-verge-bin/clash-verge-bin-2.3.2.ebuild
+++ b/net-proxy/clash-verge-bin/clash-verge-bin-2.3.2.ebuild
@@ -8,14 +8,14 @@ inherit desktop unpacker xdg
 DESCRIPTION="(Continuation) of Clash Meta GUI based on Tauri. "
 HOMEPAGE="https://github.com/clash-verge-rev/clash-verge-rev"
 SRC_URI="
-	amd64? ( https://github.com/clash-verge-rev/clash-verge-rev/releases/download/autobuild/Clash.Verge_${PV}_amd64.deb )
-	arm64? ( https://github.com/clash-verge-rev/clash-verge-rev/releases/download/autobuild/Clash.Verge_${PV}_arm64.deb )
+	amd64? ( https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v${PV}/Clash.Verge_${PV}_amd64.deb )
+	arm64? ( https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v${PV}/Clash.Verge_${PV}_arm64.deb )
 "
 
 S="${WORKDIR}"
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64 ~arm64"
 
 DEPEND="
 	dev-libs/libayatana-appindicator


### PR DESCRIPTION
Closes: https://github.com/microcai/gentoo-zh/issues/7597