### PR TITLE
acct-user/sing-box: add ACCT_USER_HOME to fix wrong certmagic ssl

### DIFF
--- a/acct-user/sing-box/sing-box-0-r1.ebuild
+++ b/acct-user/sing-box/sing-box-0-r1.ebuild
@@ -7,5 +7,6 @@ inherit acct-user
 
 ACCT_USER_ID=-1
 ACCT_USER_GROUPS=( sing-box )
+ACCT_USER_HOME="/var/lib/sing-box"
 
 acct-user_add_deps

--- a/net-proxy/sing-box/sing-box-1.12.4-r1.ebuild
+++ b/net-proxy/sing-box/sing-box-1.12.4-r1.ebuild
@@ -61,7 +61,7 @@ src_install() {
 	newins release/config/config.json config.json.example
 
 	doinitd release/config/sing-box.initd
-	systemd_dounit release/config/sing-box{,@}.service
+	systemd_dounit release/config/sing-box.service
 
 	insinto /usr/share/dbus-1/system.d
 	newins release/config/sing-box-split-dns.xml sing-box-dns.conf


### PR DESCRIPTION
Closes: https://github.com/microcai/gentoo-zh/issues/7934