### PR TITLE
treewide: fix variable order

### DIFF
--- a/media-fonts/smiley-sans/smiley-sans-2.0.1.ebuild
+++ b/media-fonts/smiley-sans/smiley-sans-2.0.1.ebuild
@@ -9,12 +9,12 @@ MY_PN="SmileySans"
 DESCRIPTION="An open-source font for Chinese."
 HOMEPAGE="https://github.com/atelier-anchor/smiley-sans"
 SRC_URI="https://github.com/atelier-anchor/smiley-sans/releases/download/v${PV}/smiley-sans-v${PV}.zip -> ${P}.zip"
+S=${WORKDIR}
 
 LICENSE="OFL-1.1"
 SLOT="0"
 KEYWORDS="~amd64"
 BDEPEND="app-arch/unzip"
-S=${WORKDIR}
 FONT_SUFFIX="ttf otf"
 
 src_unpack() {

--- a/media-fonts/tiejili/tiejili-1.100.ebuild
+++ b/media-fonts/tiejili/tiejili-1.100.ebuild
@@ -9,12 +9,12 @@ MY_PN="Tiejili"
 DESCRIPTION="An open-source font that extends  Reggae One to Chinese."
 HOMEPAGE="https://github.com/Buernia/Tiejili"
 SRC_URI="https://github.com/Buernia/Tiejili/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MY_PN}-${PV}"
 
 LICENSE="OFL-1.1"
 SLOT="0"
 KEYWORDS="~amd64"
 
-S="${WORKDIR}/${MY_PN}-${PV}"
 FONT_SUFFIX="ttf otf"
 
 src_unpack() {

--- a/media-sound/listen1_desktop-bin/listen1_desktop-bin-2.32.0.ebuild
+++ b/media-sound/listen1_desktop-bin/listen1_desktop-bin-2.32.0.ebuild
@@ -9,8 +9,8 @@ DESCRIPTION="one for all free music in China"
 HOMEPAGE="http://listen1.github.io/listen1
 	https://github.com/listen1/listen1_desktop
 "
-S="${WORKDIR}"
 SRC_URI="https://github.com/listen1/listen1_desktop/releases/download/v${PV}/listen1_${PV}_linux_amd64.deb -> ${P}.deb"
+S="${WORKDIR}"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-video/amdgpu-pro-amf/amdgpu-pro-amf-1.4.29.1538781.ebuild
+++ b/media-video/amdgpu-pro-amf/amdgpu-pro-amf-1.4.29.1538781.ebuild
@@ -23,11 +23,11 @@ SRC_URI="https://repo.radeon.com/amdgpu/${PRO_VULKAN_PKG_VER}/ubuntu/pool/propri
 
 S="${WORKDIR}"
 
-RESTRICT="bindist mirror"
-
 LICENSE="AMD-GPU-PRO-EULA"
 SLOT="0"
 KEYWORDS="-* ~amd64"
+
+RESTRICT="bindist mirror"
 
 RDEPEND="
 	media-libs/amdgpu-pro-vulkan


### PR DESCRIPTION
Fix pkgcheck `VariableOrderWrong` findings for the subset that passed CI emerge jobs.

Retained in this PR after the CI split:
- `media-fonts/smiley-sans`
- `media-fonts/tiejili`
- `media-sound/listen1_desktop-bin`
- `media-video/amdgpu-pro-amf`

Moved out because their package emerge jobs failed in CI:
- `app-emulation/deepin-wine-helper`
- `app-emulation/looking-glass`
- `dev-embedded/at32workbench`
- `dev-python/frozendict`
- `games-misc/oh-my-git-bin`
- `media-gfx/zw3d`
- `media-gfx/zwcad`
- `media-video/implay`
- `net-libs/jzmq`
- `net-misc/pcmanx-gtk2`
- `net-misc/remmina-plugin-rustdesk`
- `x11-misc/picom-jonaburg`

The failing-package commits are preserved on branch `pkgcheck-variable-order-failing-20260430` in the fork, without opening a separate PR.

Verification:
- Previous PR CI passed pkgcheck and passed emerge for the four retained packages.
- New CI was retriggered after force-pushing the split branch.
