### PR TITLE
metadata: drop redundant longdescription entries

### DIFF
--- a/app-misc/mdx_util/metadata.xml
+++ b/app-misc/mdx_util/metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<longdescription lang="en">
-		A command line tools for handling mdx related jobs.
-	</longdescription>
 	<upstream>
 		<remote-id type="github">raymanzhang/mdx_util</remote-id>
 	</upstream>

--- a/gnome-extra/gnome-shell-extension-clipboard-indicator/metadata.xml
+++ b/gnome-extra/gnome-shell-extension-clipboard-indicator/metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<longdescription lang="en">
-		The most popular clipboard manager for GNOME, with over 1M downloads
-	</longdescription>
 	<upstream>
 		<remote-id type="github">Tudmotu/gnome-shell-extension-clipboard-indicator</remote-id>
 	</upstream>

--- a/gnome-extra/resources/metadata.xml
+++ b/gnome-extra/resources/metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<longdescription lang="en">
-		Keep an eye on system resources
-	</longdescription>
 	<upstream>
 		<remote-id type="github">nokyan/resources</remote-id>
 	</upstream>

--- a/media-libs/glycin-thumbnailer/metadata.xml
+++ b/media-libs/glycin-thumbnailer/metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<longdescription lang="en">
-		Thumbnailer for glycin clients.
-	</longdescription>
 	<upstream>
 		<remote-id type="gnome-gitlab">GNOME/glycin</remote-id>
 	</upstream>

--- a/media-sound/euphonica/metadata.xml
+++ b/media-sound/euphonica/metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-    <longdescription lang="en">
-        An MPD client with delusions of grandeur, made with Rust, GTK and Libadwaita.
-    </longdescription>
     <upstream>
         <remote-id type="github">htkhiem/euphonica</remote-id>
     </upstream>


### PR DESCRIPTION
Summary:\n- drop redundant or too-short metadata.xml longdescription entries\n- keep this PR limited to metadata-only updates\n\nPackages:\n- app-misc/mdx_util\n- gnome-extra/gnome-shell-extension-clipboard-indicator\n- gnome-extra/resources\n- media-libs/glycin-thumbnailer\n- media-sound/euphonica\n\nTests:\n- pkgcheck scan --commits origin/master