### PR TITLE
net-proxy/clash-verge-rev: use cmake for partial -O0

### DIFF
--- a/net-proxy/clash-verge-rev/clash-verge-rev-2.4.7.ebuild
+++ b/net-proxy/clash-verge-rev/clash-verge-rev-2.4.7.ebuild
@@ -61,6 +61,7 @@ RDEPEND="
 BDEPEND="
 	${COMMON_DEPEND}
 	app-misc/jq
+	dev-build/cmake
 	dev-util/patchelf
 	sys-apps/moreutils
 "
@@ -80,7 +81,8 @@ src_prepare() {
 src_compile() {
 	#aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/src/jitterentropy-base.c:
 	#The CPU Jitter random number generator must not be compiled with optimizations.
-	export AWS_LC_SYS_CFLAGS="${CFLAGS} -O0"
+	#Force use of cmake to auto apply -O0 to related parts
+	export AWS_LC_SYS_CMAKE_BUILDER=1
 
 	lto-guarantee-fat
 


### PR DESCRIPTION
让cmake决定怎么构建jitterentropy-library
这个库要测量低效代码的执行时间差异
要求改掉的CFLAGS还挺多的
https://github.com/aws/aws-lc/blob/main/third_party/jitterentropy/CMakeLists.txt

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
