### PR TITLE
treewide: add python3_14 targets (CI-passing subset)

### DIFF
--- a/app-backup/snapper-gui/snapper-gui-220626.ebuild
+++ b/app-backup/snapper-gui/snapper-gui-220626.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{10..14} )
 COMMIT_ID="191575084a4e951802c32a4177dc704cf435883a"
 inherit distutils-r1
 

--- a/dev-python/archspec/archspec-0.2.5.ebuild
+++ b/dev-python/archspec/archspec-0.2.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..13} )
+PYTHON_COMPAT=( python3_{9..14} )
 
 inherit distutils-r1
 

--- a/dev-python/conda-libmamba-solver/conda-libmamba-solver-26.3.0.ebuild
+++ b/dev-python/conda-libmamba-solver/conda-libmamba-solver-26.3.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{9..13} )
+PYTHON_COMPAT=( python3_{9..14} )
 inherit distutils-r1
 
 DESCRIPTION="The libmamba based solver for conda"

--- a/dev-python/conda-package-handling/conda-package-handling-2.4.0.ebuild
+++ b/dev-python/conda-package-handling/conda-package-handling-2.4.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..13} pypy3 )
+PYTHON_COMPAT=( python3_{9..14} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Create and extract conda packages of various formats"

--- a/dev-python/conda-package-streaming/conda-package-streaming-0.12.0.ebuild
+++ b/dev-python/conda-package-streaming/conda-package-streaming-0.12.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=(python3_{9..13})
+PYTHON_COMPAT=(python3_{9..14})
 inherit distutils-r1
 
 DESCRIPTION="An efficient library to read from new and old conda packages"

--- a/dev-python/conda/conda-26.3.2.ebuild
+++ b/dev-python/conda/conda-26.3.2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{9..13} )
+PYTHON_COMPAT=( python3_{9..14} )
 inherit distutils-r1
 
 DESCRIPTION="OS-agnostic, system-level binary package manager and ecosystem"

--- a/dev-python/pyqt6-charts/pyqt6-charts-6.10.0.ebuild
+++ b/dev-python/pyqt6-charts/pyqt6-charts-6.10.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=sip
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 inherit distutils-r1 flag-o-matic multiprocessing pypi qmake-utils
 
 QT_PV=$(ver_cut 1-2):6

--- a/dev-util/osc/osc-1.26.0.ebuild
+++ b/dev-util/osc/osc-1.26.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..13} python3_13t )
+PYTHON_COMPAT=( python3_{10..14} python3_13t )
 inherit distutils-r1
 
 DESCRIPTION="The Command Line Interface to work with an Open Build Service"

--- a/www-servers/woof/woof-9999.ebuild
+++ b/www-servers/woof/woof-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..14} )
 
 inherit git-r3 python-single-r1
 

--- a/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
+++ b/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..14} )
 inherit meson python-any-r1 virtualx xdg
 
 DESCRIPTION="jonaburg's picom fork with dual_kawase blur and rounded corners"

--- a/x11-themes/fcitx-breeze/fcitx-breeze-3.1.0.ebuild
+++ b/x11-themes/fcitx-breeze/fcitx-breeze-3.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} python3_13t )
+PYTHON_COMPAT=( python3_{10..14} python3_13t )
 inherit python-any-r1
 
 EGIT_COMMIT=59456757ca1f0736dcf03b507f661a3693f5b51d


### PR DESCRIPTION
Split out the Python 3.14 compatibility updates from the pkgcheck cleanup branches.

Verified with:
- pkgcheck scan --commits -q
