### PR TITLE
net-misc/reframe: fix libvncserver dep to be conditional on !neatvnc

### DIFF
--- a/net-misc/reframe/files/reframe-1.15.1-libvncserver-optional.patch
+++ b/net-misc/reframe/files/reframe-1.15.1-libvncserver-optional.patch
@@ -1,0 +1,56 @@
+diff --git a/reframe-server/meson.build b/reframe-server/meson.build
+index 8a27483..321ec82 100644
+--- a/reframe-server/meson.build
++++ b/reframe-server/meson.build
+@@ -49,29 +49,31 @@ executable(
+   install: true
+ )
+ 
+-lvnc_sources = files('rf-lvnc-server.c')
++if not get_option('neatvnc') or not neatvnc.found()
++  lvnc_sources = files('rf-lvnc-server.c')
+ 
+-lvnc_headers = files('rf-lvnc-server.h')
++  lvnc_headers = files('rf-lvnc-server.h')
+ 
+-lvnc_dependencies = []
+-libvncserver = dependency('libvncserver', required: true)
+-lvnc_dependencies += [
+-  glib,
+-  gio,
+-  gmodule,
+-  gobject,
+-  libvncserver,
+-  reframe_common_dep
+-]
++  lvnc_dependencies = []
++  libvncserver = dependency('libvncserver', required: true)
++  lvnc_dependencies += [
++    glib,
++    gio,
++    gmodule,
++    gobject,
++    libvncserver,
++    reframe_common_dep
++  ]
+ 
+-shared_module(
+-  meson.project_name() + '-libvncserver',
+-  sources: lvnc_sources,
+-  dependencies: lvnc_dependencies,
+-  include_directories: include_directories,
+-  install: true,
+-  install_dir: moduledir / 'vnc'
+-)
++  shared_module(
++    meson.project_name() + '-libvncserver',
++    sources: lvnc_sources,
++    dependencies: lvnc_dependencies,
++    include_directories: include_directories,
++    install: true,
++    install_dir: moduledir / 'vnc'
++  )
++endif
+ 
+ if get_option('neatvnc') and neatvnc.found()
+   nvnc_sources = files('rf-nvnc-server.c')

--- a/net-misc/reframe/files/reframe-server.initd
+++ b/net-misc/reframe/files/reframe-server.initd
@@ -1,0 +1,54 @@
+#!/sbin/openrc-run
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="ReFrame remote desktop server"
+
+instance="${RC_SVCNAME#*.}"
+if [ "${instance}" = "${RC_SVCNAME}" ]; then
+	instance=default
+fi
+
+: "${REFRAME_CONFBASEDIR:=/etc/reframe}"
+: "${REFRAME_USER:=reframe}"
+: "${REFRAME_GROUP:=reframe}"
+: "${REFRAME_SOCKETDIR:=/run/reframe}"
+: "${REFRAME_SESSION_SOCKETDIR:=/run/reframe-session}"
+: "${REFRAME_LOGDIR:=/var/log/reframe}"
+
+cfgfile="${REFRAME_CONFBASEDIR}/${instance}.conf"
+if [ "${instance}" = default ] && [ ! -f "${cfgfile}" ] \
+	&& [ -f "${REFRAME_CONFBASEDIR}/example.conf" ]; then
+	cfgfile="${REFRAME_CONFBASEDIR}/example.conf"
+fi
+
+command="/usr/bin/reframe-server"
+command_user="${REFRAME_USER}:${REFRAME_GROUP}"
+command_args="--config=${cfgfile} --socket=${REFRAME_SOCKETDIR}/${instance}.sock --session-socket=${REFRAME_SESSION_SOCKETDIR}/${instance}.sock"
+supervisor=supervise-daemon
+supervise_daemon_args="-e EGL_PLATFORM=surfaceless"
+pidfile="/run/${RC_SVCNAME}.pid"
+output_log="${REFRAME_LOGDIR}/${RC_SVCNAME}.log"
+error_log="${REFRAME_LOGDIR}/${RC_SVCNAME}.log"
+
+depend() {
+	if [ "${instance}" = default ]; then
+		need reframe-streamer
+	else
+		need "reframe-streamer.${instance}"
+	fi
+	use net
+}
+
+start_pre() {
+	if [ ! -f "${cfgfile}" ]; then
+		eerror "Configuration file ${cfgfile} not found."
+		eerror "Create one based on ${REFRAME_CONFBASEDIR}/example.conf"
+		return 1
+	fi
+
+	checkpath -d -m 0755 -o root:root "${REFRAME_SOCKETDIR}"
+	checkpath -d -m 0755 -o "${command_user}" "${REFRAME_SESSION_SOCKETDIR}"
+	checkpath -d -m 0755 -o "${command_user}" "${REFRAME_LOGDIR}"
+	checkpath -f -m 0644 -o "${command_user}" "${output_log}"
+}

--- a/net-misc/reframe/files/reframe-streamer.initd
+++ b/net-misc/reframe/files/reframe-streamer.initd
@@ -1,0 +1,44 @@
+#!/sbin/openrc-run
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="ReFrame remote desktop streamer"
+
+instance="${RC_SVCNAME#*.}"
+if [ "${instance}" = "${RC_SVCNAME}" ]; then
+	instance=default
+fi
+
+: "${REFRAME_CONFBASEDIR:=/etc/reframe}"
+: "${REFRAME_SOCKETDIR:=/run/reframe}"
+: "${REFRAME_LOGDIR:=/var/log/reframe}"
+
+cfgfile="${REFRAME_CONFBASEDIR}/${instance}.conf"
+if [ "${instance}" = default ] && [ ! -f "${cfgfile}" ] \
+	&& [ -f "${REFRAME_CONFBASEDIR}/example.conf" ]; then
+	cfgfile="${REFRAME_CONFBASEDIR}/example.conf"
+fi
+
+command="/usr/bin/reframe-streamer"
+command_args="--config=${cfgfile} --socket=${REFRAME_SOCKETDIR}/${instance}.sock"
+supervisor=supervise-daemon
+pidfile="/run/${RC_SVCNAME}.pid"
+output_log="${REFRAME_LOGDIR}/${RC_SVCNAME}.log"
+error_log="${REFRAME_LOGDIR}/${RC_SVCNAME}.log"
+
+depend() {
+	after localmount
+	use net
+}
+
+start_pre() {
+	if [ ! -f "${cfgfile}" ]; then
+		eerror "Configuration file ${cfgfile} not found."
+		eerror "Create one based on ${REFRAME_CONFBASEDIR}/example.conf"
+		return 1
+	fi
+
+	checkpath -d -m 0755 -o root:root "${REFRAME_SOCKETDIR}"
+	checkpath -d -m 0755 -o root:root "${REFRAME_LOGDIR}"
+	checkpath -f -m 0644 -o root:root "${output_log}"
+}

--- a/net-misc/reframe/files/reframe.confd
+++ b/net-misc/reframe/files/reframe.confd
@@ -1,0 +1,28 @@
+# Shared configuration for reframe-server and reframe-streamer OpenRC services.
+# Install this file as both /etc/conf.d/reframe-server and
+# /etc/conf.d/reframe-streamer.
+#
+# The base services reframe-server and reframe-streamer run the default
+# instance. They use ${REFRAME_CONFBASEDIR}/default.conf when present,
+# otherwise they fall back to ${REFRAME_CONFBASEDIR}/example.conf.
+#
+# Additional instances can be created via symlink, for example
+# reframe-server.work -> instance="work".
+#
+# The config file for each instance is ${REFRAME_CONFBASEDIR}/${instance}.conf
+# The socket path for each instance is ${REFRAME_SOCKETDIR}/${instance}.sock
+
+# Base directory for configuration files.
+#REFRAME_CONFBASEDIR="/etc/reframe"
+
+# User for reframe-server process.
+#REFRAME_USER="reframe"
+
+# Group for reframe-server process.
+#REFRAME_GROUP="reframe"
+
+# Directory for streamer-to-server communication sockets.
+#REFRAME_SOCKETDIR="/run/reframe"
+
+# Directory for session communication sockets.
+#REFRAME_SESSION_SOCKETDIR="/run/reframe-session"

--- a/net-misc/reframe/reframe-1.15.1.ebuild
+++ b/net-misc/reframe/reframe-1.15.1.ebuild
@@ -58,6 +58,20 @@ src_configure() {
 	meson_src_configure
 }
 
+src_install() {
+	meson_src_install
+
+	newinitd "${FILESDIR}/reframe-server.initd" reframe-server
+	newinitd "${FILESDIR}/reframe-streamer.initd" reframe-streamer
+	newconfd "${FILESDIR}/reframe.confd" reframe-server
+	newconfd "${FILESDIR}/reframe.confd" reframe-streamer
+
+	if use neatvnc; then
+		sed -i -e 's/^type=libvncserver$/type=neatvnc/' \
+			"${ED}/etc/reframe/example.conf" || die
+	fi
+}
+
 pkg_postinst() {
 	if use systemd; then
 		tmpfiles_process reframe-tmpfiles.conf

--- a/net-misc/reframe/reframe-1.15.1.ebuild
+++ b/net-misc/reframe/reframe-1.15.1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	gui-libs/gtk:4
 	x11-libs/libdrm
 	media-libs/libepoxy
-	net-libs/libvncserver
+	!neatvnc? ( net-libs/libvncserver )
 	x11-libs/libxkbcommon
 	neatvnc? (
 		gui-libs/neatvnc
@@ -38,6 +38,10 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-libvncserver-optional.patch"
+)
 
 src_prepare() {
 	rm -rf "${S}/deps/mvmath"


### PR DESCRIPTION
## Summary

- `net-misc/reframe-1.15.1` 的 `neatvnc` USE 标志启时仍无条件依赖 `net-libs/libvncserver`，导致启用 neatvnc 后两个 VNC 实现同时被拉入
- 将 `libvncserver` 依赖改为 `!neatvnc? ( net-libs/libvncserver )`，使二者互斥