### PR TITLE
net-misc/reframe: make libvncserver conditional on !neatvnc

### DIFF
--- a/net-misc/reframe/files/reframe-1.15.1-libvncserver-optional.patch
+++ b/net-misc/reframe/files/reframe-1.15.1-libvncserver-optional.patch
@@ -1,0 +1,56 @@
+diff --git a/reframe-server/meson.build b/reframe-server/meson.build
+index 8a27483..321ec82 100644
+--- a/reframe-server/meson.build
++++ b/reframe-server/meson.build
+@@ -49,29 +49,31 @@ executable(
+   install: true
+ )
+ 
+-lvnc_sources = files('rf-lvnc-server.c')
++if not get_option('neatvnc') or not neatvnc.found()
++  lvnc_sources = files('rf-lvnc-server.c')
+ 
+-lvnc_headers = files('rf-lvnc-server.h')
++  lvnc_headers = files('rf-lvnc-server.h')
+ 
+-lvnc_dependencies = []
+-libvncserver = dependency('libvncserver', required: true)
+-lvnc_dependencies += [
+-  glib,
+-  gio,
+-  gmodule,
+-  gobject,
+-  libvncserver,
+-  reframe_common_dep
+-]
++  lvnc_dependencies = []
++  libvncserver = dependency('libvncserver', required: true)
++  lvnc_dependencies += [
++    glib,
++    gio,
++    gmodule,
++    gobject,
++    libvncserver,
++    reframe_common_dep
++  ]
+ 
+-shared_module(
+-  meson.project_name() + '-libvncserver',
+-  sources: lvnc_sources,
+-  dependencies: lvnc_dependencies,
+-  include_directories: include_directories,
+-  install: true,
+-  install_dir: moduledir / 'vnc'
+-)
++  shared_module(
++    meson.project_name() + '-libvncserver',
++    sources: lvnc_sources,
++    dependencies: lvnc_dependencies,
++    include_directories: include_directories,
++    install: true,
++    install_dir: moduledir / 'vnc'
++  )
++endif
+ 
+ if get_option('neatvnc') and neatvnc.found()
+   nvnc_sources = files('rf-nvnc-server.c')

--- a/net-misc/reframe/reframe-1.15.1.ebuild
+++ b/net-misc/reframe/reframe-1.15.1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	gui-libs/gtk:4
 	x11-libs/libdrm
 	media-libs/libepoxy
-	net-libs/libvncserver
+	!neatvnc? ( net-libs/libvncserver )
 	x11-libs/libxkbcommon
 	neatvnc? (
 		gui-libs/neatvnc
@@ -38,6 +38,10 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-libvncserver-optional.patch"
+)
 
 src_prepare() {
 	rm -rf "${S}/deps/mvmath"


### PR DESCRIPTION
## Summary
- make libvncserver conditional on !neatvnc
- only build the libvncserver VNC module when the libvncserver backend is actually needed
- avoid forcing the libvncserver build dependency when USE=neatvnc
