### PR TITLE
app-i18n/vocotype: enable python3_14 with deps

### DIFF
--- a/app-i18n/vocotype/vocotype-2.1.3-r1.ebuild
+++ b/app-i18n/vocotype/vocotype-2.1.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 multiprocessing systemd xdg-utils
 

--- a/dev-python/funasr-onnx/funasr-onnx-0.4.1-r1.ebuild
+++ b/dev-python/funasr-onnx/funasr-onnx-0.4.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 


### PR DESCRIPTION
vocotype RDEPEND requires funasr-onnx[python_targets_python3_14], so both bumps must land together.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.