### PR TITLE
sci-electronics/lceda-pro: fix unpack warning

### DIFF
--- a/sci-electronics/lceda-pro/lceda-pro-3.2.135.ebuild
+++ b/sci-electronics/lceda-pro/lceda-pro-3.2.135.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit desktop xdg
+inherit desktop unpacker xdg
 
 DESCRIPTION="LCEDA Pro (binary package)"
 HOMEPAGE="https://lceda.cn/"
@@ -63,11 +63,6 @@ QA_PREBUILT="
 	/opt/lceda-pro/libGLESv2.so
 	/opt/lceda-pro/libvulkan.so.1
 "
-
-src_unpack(){
-	export LANG=C.UTF-8
-	unpack ${A}
-}
 
 src_install(){
 	insinto /opt/lceda-pro

--- a/sci-electronics/lceda-pro/lceda-pro-3.2.149.ebuild
+++ b/sci-electronics/lceda-pro/lceda-pro-3.2.149.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit desktop xdg
+inherit desktop unpacker xdg
 
 DESCRIPTION="LCEDA Pro (binary package)"
 HOMEPAGE="https://lceda.cn/"
@@ -63,11 +63,6 @@ QA_PREBUILT="
 	/opt/lceda-pro/libGLESv2.so
 	/opt/lceda-pro/libvulkan.so.1
 "
-
-src_unpack(){
-	export LANG=C.UTF-8
-	unpack ${A}
-}
 
 src_install(){
 	insinto /opt/lceda-pro


### PR DESCRIPTION
Use unpacker.eclass so unzip warning exit status 1 is not treated as fatal.

Tested:
- pkgcheck scan sci-electronics/lceda-pro
- ebuild sci-electronics/lceda-pro/lceda-pro-3.2.149.ebuild clean package