### PR TITLE
media-video/bilibili: avoid scanelf on non-linux modules

### DIFF
--- a/media-video/bilibili/bilibili-1.17.9_p1.ebuild
+++ b/media-video/bilibili/bilibili-1.17.9_p1.ebuild
@@ -24,9 +24,12 @@ IUSE="wayland"
 RESTRICT="strip"
 
 RDEPEND="
+	dev-libs/libinput
 	dev-libs/nss
 	media-libs/alsa-lib
+	media-libs/mesa[gbm(+)]
 	x11-libs/gtk+:*
+	x11-libs/libdrm
 	x11-libs/libxkbcommon
 	x11-libs/libX11
 	x11-libs/libXext

--- a/media-video/bilibili/bilibili-1.17.9_p1.ebuild
+++ b/media-video/bilibili/bilibili-1.17.9_p1.ebuild
@@ -21,6 +21,8 @@ KEYWORDS="-* ~amd64 ~arm64"
 
 IUSE="wayland"
 
+RESTRICT="strip"
+
 RDEPEND="
 	dev-libs/nss
 	media-libs/alsa-lib
@@ -39,6 +41,15 @@ RDEPEND="
 QA_PREBUILT="*"
 
 src_install() {
+	local app_dir="opt/apps/${FPN}/files/bin/app"
+
+	# Drop non-Linux native modules; scanelf cannot handle their .lib archives.
+	rm -rf \
+		"${app_dir}/app/node_modules/@nut-tree/libnut-darwin" \
+		"${app_dir}/app/node_modules/@nut-tree/libnut-win32" \
+		"${app_dir}/app.asar.unpacked/node_modules/@nut-tree/libnut-win32" \
+		|| die
+
 	insinto "/"
 	doins -r "opt"
 	doicon -s "scalable" "usr/share/icons/hicolor/scalable/apps/${FPN}.svg"

--- a/media-video/bilibili/metadata.xml
+++ b/media-video/bilibili/metadata.xml
@@ -5,6 +5,6 @@
 		<name>Boiao Ch</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">mosjocs/bilibili-linux</remote-id>
+		<remote-id type="github">msojocs/bilibili-linux</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
close #9502