### PR TITLE
app-editors/neomacs: add live package

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -95,6 +95,13 @@ github = "AppFlowy-IO/AppFlowy"
 use_latest_release = true
 github_account = "Linerre"
 
+# Neomacs is alpha-stage, so gentoo-zh carries only a live ebuild for now.
+["app-editors/neomacs"]
+source = "github"
+github = "eval-exec/neomacs"
+use_latest_release = true
+prefix = "v"
+github_account = "xz-dev"
 
 ["dev-lang/dart"]
 source = "apt"

--- a/app-editors/neomacs/metadata.xml
+++ b/app-editors/neomacs/metadata.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>xiangzhedev@gmail.com</email>
+		<name>xz-dev</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">eval-exec/neomacs</remote-id>
+		<bugs-to>https://github.com/eval-exec/neomacs/issues</bugs-to>
+	</upstream>
+	<longdescription>
+		NEO Emacs is a GPU powered Emacs written in Rust with a modern display
+		engine. Aiming for modern design &amp; multi-threaded Elisp, 10x
+		performance, zero-pause concurrent GC and 100% Emacs compatibility.
+	</longdescription>
+	<use>
+		<flag name="jit">Enable just-in-time compilation support</flag>
+		<flag name="terminal">Enable the embedded terminal emulator feature</flag>
+		<flag name="video">Enable GStreamer-backed inline video support</flag>
+	</use>
+</pkgmetadata>

--- a/app-editors/neomacs/neomacs-9999.ebuild
+++ b/app-editors/neomacs/neomacs-9999.ebuild
@@ -1,0 +1,136 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+RUST_MIN_VER="1.95.0"
+
+inherit cargo desktop git-r3 toolchain-funcs xdg
+
+DESCRIPTION="Modern Emacs fork rewriting Emacs internals in Rust"
+HOMEPAGE="https://github.com/eval-exec/neomacs"
+EGIT_REPO_URI="https://github.com/eval-exec/neomacs.git"
+
+LICENSE="GPL-3+ FDL-1.3+ CC-BY-SA-3.0 CC-BY-SA-4.0 CC-BY-4.0 HPND PCRE PSF-2 unicode W3C"
+# Dependent crate licenses
+LICENSE+="
+	Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD-2 BSD Boost-1.0
+	CC0-1.0 CDLA-Permissive-2.0 ISC LGPL-3 MIT MPL-2.0 UoI-NCSA
+	Unicode-3.0 Unicode-DFS-2016 ZLIB
+"
+SLOT="0"
+IUSE="+jit +terminal +video"
+
+RESTRICT="test"
+
+DEPEND="
+	dev-libs/wayland
+	media-libs/fontconfig
+	media-libs/mesa
+	dev-db/sqlite:3
+	media-libs/vulkan-loader[X,wayland]
+	sys-libs/ncurses:=
+	x11-libs/libX11
+	x11-libs/libXcursor
+	x11-libs/libXfixes
+	x11-libs/libXi
+	x11-libs/libXrandr
+	x11-libs/libXrender
+	x11-libs/libxcb
+	x11-libs/libxkbcommon[X]
+	video? (
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+"
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( BUGS CONTRIBUTE README.md )
+
+src_unpack() {
+	git-r3_src_unpack
+	cargo_live_src_unpack
+}
+
+src_prepare() {
+	default
+
+	# Prefer Gentoo's system sqlite over rusqlite/libsqlite3-sys' bundled copy.
+	sed -i -e 's/"bundled"//' Cargo.toml || die
+}
+
+src_configure() {
+	local myfeatures=(
+		$(usev jit)
+		$(usev terminal neo-term)
+		$(usev video)
+	)
+	cargo_src_configure --no-default-features
+}
+
+src_compile() {
+	# Upstream's build script probes ncurses for the library target, but the
+	# final binary also needs the full ncursesw linker set for termcap symbols.
+	local ncurses_libs ncurses_link
+	ncurses_libs=$("$(tc-getPKG_CONFIG)" --libs ncursesw) || die "failed to query ncursesw libs"
+	for ncurses_link in ${ncurses_libs}; do
+		RUSTFLAGS+=" -C link-arg=${ncurses_link}"
+	done
+
+	cargo_src_compile -p ${PN}
+
+	cargo_env cargo xtask \
+		fresh-build \
+		--release \
+		--skip-build \
+		--bin-dir "$(cargo_target_dir)" \
+		--runtime-root "${S}" || die
+}
+
+src_install() {
+	local target_dir=$(cargo_target_dir)
+
+	exeinto /usr/libexec/${PN}
+	doexe "${target_dir}"/${PN}
+
+	insinto /usr/libexec/${PN}
+	doins "${target_dir}"/${PN}.pdump
+
+	dodir /usr/bin
+	cat > "${ED}"/usr/bin/${PN} <<-EOF || die
+		#!/bin/sh
+		export NEOMACS_RUNTIME_ROOT="\${NEOMACS_RUNTIME_ROOT:-${EPREFIX}/usr/share/${PN}}"
+		exec "${EPREFIX}/usr/libexec/${PN}/${PN}" "\$@"
+	EOF
+	fperms 0755 /usr/bin/${PN}
+
+	insinto /usr/share/${PN}
+	doins -r etc lisp
+
+	newicon -s 128 assets/logo-128.png ${PN}.png
+	newicon -s scalable assets/window-icon.svg ${PN}.svg
+	make_desktop_entry \
+		--eapi9 \
+		-n "Neomacs" \
+		-i ${PN} \
+		-c "Development;TextEditor" \
+		-e "MimeType=text/plain;text/x-c;text/x-c++;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-makefile;text/x-python;text/x-rust;application/x-shellscript;" \
+		-e "StartupWMClass=Neomacs" \
+		${PN}
+
+	einstalldocs
+	dodoc -r docs
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	elog "Neomacs is alpha software; live builds may change or break at any time."
+	if use video; then
+		elog "Install GStreamer plugin packages as needed for the media formats you want to play."
+	fi
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+}


### PR DESCRIPTION
Add `app-editors/neomacs` from gen-fast as a live-only package maintained by xz-dev.

Only a live ebuild is added for now because Neomacs is still a very new alpha-stage project with rapidly changing internals. The nvchecker entry is intentionally added at the same time so the gentoo-zh bumpbot already knows the upstream GitHub release stream and maintainer (`xz-dev`); stable ebuilds can be added later once the project/package settles enough for normal release packaging.

Validation:
- `pkgcheck scan app-editors/neomacs`
- `DISTDIR=/tmp/gentoo-zh-neomacs-distfiles PKGDIR=/tmp/gentoo-zh-neomacs-binpkgs ebuild app-editors/neomacs/neomacs-9999.ebuild manifest clean package`
- `pkgcheck scan --staged --net`
- `pkgcheck scan --commits --net`

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
