### PR TITLE
net-misc/baidunetdisk: add 8.5.2-r1

### DIFF
--- a/net-misc/baidunetdisk/baidunetdisk-8.5.2-r1.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-8.5.2-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 2020-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit unpacker desktop xdg
+
+SPECIAL_DIRVER="${PV}.427"
+# I don't know why Baidu changed the URL structure, but they did,
+# so I add this to match the new 4-digit directory version.
+
+DESCRIPTION="Baidu Net Disk is a cloud storage client (Linux Version)"
+HOMEPAGE="https://pan.baidu.com/"
+SRC_URI="http://wppkg.baidupcs.com/issue/netdisk/Linuxguanjia/${SPECIAL_DIRVER}/${PN}_${PV}_amd64.deb"
+
+S="${WORKDIR}"
+
+LICENSE="BaiduNetDisk"
+SLOT="0"
+KEYWORDS="-* ~amd64"
+RESTRICT="strip mirror"
+
+RDEPEND="
+	app-crypt/p11-kit
+	dev-libs/nss
+	media-libs/alsa-lib
+	x11-libs/gtk+:3[cups,X,wayland]
+	x11-libs/libXScrnSaver
+	x11-libs/libXtst
+	dev-cpp/gtkmm:2.4
+"
+
+QA_PREBUILT="*"
+
+src_install() {
+	# Preserve original permissions, symlinks and executable bits
+	cp -a opt "${ED}" || die
+
+	# Remove unnecessary node-gyp helper directories
+	find "${ED}/opt/${PN}" -type d -name "node_gyp_bins" -exec rm -rf {} + 2>/dev/null || die
+	find "${ED}" -type d -empty -delete || die
+
+	dosym -r /opt/${PN}/${PN} /usr/bin/${PN}
+
+	gzip -d usr/share/doc/${PN}/*.gz || die
+	dodoc usr/share/doc/${PN}/*
+
+	domenu usr/share/applications/${PN}.desktop
+	doicon -s scalable usr/share/icons/hicolor/scalable/apps/${PN}.svg
+}


### PR DESCRIPTION
Preserve executable bits from the upstream .deb package by installing the extracted files with cp -a instead of doins -r.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
