### PR TITLE
dev-python/numba: cap numpy below 2.5 in RDEPEND

### DIFF
--- a/dev-python/numba/numba-0.64.0-r1.ebuild
+++ b/dev-python/numba/numba-0.64.0-r1.ebuild
@@ -35,6 +35,7 @@ KEYWORDS="~amd64"
 RDEPEND="
 	>=dev-python/llvmlite-0.46.0[${PYTHON_USEDEP}]
 	>=dev-python/numpy-1.22[${PYTHON_USEDEP}]
+	<dev-python/numpy-2.5[${PYTHON_USEDEP}]
 "
 
 RESTRICT="bindist mirror strip test"


### PR DESCRIPTION
numba aborts at import on numpy 2.5 or newer, so this restores upstream's `numpy<2.5` pin that the ebuild had dropped.

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.