### PR TITLE
ci: enable bindist for qtwebengine binhost

### DIFF
--- a/.github/workflows/emerge-on-pr.yml
+++ b/.github/workflows/emerge-on-pr.yml
@@ -125,13 +125,17 @@ jobs:
         priority = 0
         EOF
 
-    - name: setup portage make.conf
+    - name: setup portage config
       run: |
         cat >> /etc/portage/make.conf << EOF
         FEATURES="\${FEATURES} getbinpkg"
         MAKEOPTS="\${MAKEOPTS} -j$(nproc)"
         PORTAGE_ELOG_CLASSES="qa warn error"
         PORTAGE_ELOG_SYSTEM="save"
+        EOF
+        mkdir -p /etc/portage/package.use
+        cat >> /etc/portage/package.use/ci-binhost << EOF
+        dev-qt/qtwebengine bindist
         EOF
         cat /etc/portage/make.conf
 


### PR DESCRIPTION
不加这个 qtwewbengine 没办法匹配 binhost 的 USE 组合, 不用 binary , 根本没法跑完check