### PR TITLE
app-editors/neomacs: drop nvchecker entry

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -102,14 +102,6 @@ github = "AppFlowy-IO/AppFlowy"
 use_latest_release = true
 github_account = ["Linerre", "gouwazi"]
 
-# Neomacs is alpha-stage, so gentoo-zh carries only a live ebuild for now.
-["app-editors/neomacs"]
-source = "github"
-github = "eval-exec/neomacs"
-use_latest_release = true
-prefix = "v"
-github_account = "xz-dev"
-
 ["dev-lang/dart"]
 source = "apt"
 pkg = "dart"


### PR DESCRIPTION
Closes: https://github.com/microcai/gentoo-zh/issues/10562