### PR TITLE
docs: clarify contribution workflow and add Chinese README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,15 @@ This repository is a Gentoo overlay fork. Prefer generic Gentoo ebuild workflow 
 
 ## Git Workflow
 
-- Before starting package work, ensure an `upstream` remote exists for the upstream overlay.
+- Every repository modification is PR-bound work unless the user explicitly says otherwise in the current request. This applies to ebuilds, manifests, metadata, documentation, CI files, and README-only changes.
+- Automated agents, AI assistants, scripts operating on behalf of a maintainer, and human maintainers using automation must complete the mandatory PR preflight before editing any tracked file.
+- Human-only exploratory inspection may read files without this preflight, but any tracked file edit must follow it.
+- Treat `master` as the upstream-sync branch only. Never make feature, package, documentation, CI, or metadata changes directly on `master`.
+
+### Mandatory PR Preflight
+
+- Before editing any tracked file, run `git status --short --branch`, `git branch --show-current`, and `git remote -v`.
+- Verify an `upstream` remote exists and points to `git@github.com:Gentoo-zh/overlay.git`.
 - If `upstream` is missing, add it with:
 
   ```bash
@@ -19,13 +27,22 @@ This repository is a Gentoo overlay fork. Prefer generic Gentoo ebuild workflow 
   ```
 
 - If `upstream` already exists but points elsewhere, do not silently rewrite it; report the current URL and confirm before changing it.
-- Treat `master` as the upstream-sync branch. Do not make feature work directly on `master`.
+- If currently on `master`, first sync `master` from `upstream/master`, then create a topic branch before editing.
+- If the worktree contains unrelated changes, preserve them. Do not overwrite, revert, stage, or commit unrelated changes.
+- Stop before editing and ask the user when the current branch is `master`, `upstream` is missing or points to an unexpected URL, `master` cannot be synced from `upstream/master`, unrelated local changes make branch creation or staging ambiguous, or the requested change spans multiple unrelated logical PRs.
+
+### Topic Branches
+
 - Use one topic branch per logical pull request.
-- Branch package work from a freshly synced `master`; for version bumps, prefer names like `category-package-version`.
+- Branch all PR-bound work from a freshly synced `master`; for version bumps, prefer names like `category-package-version`.
 - A pull request may touch multiple packages only when they are part of one logical contribution, such as one dependency chain, one coordinated version bump, or one shared fix.
 - Keep unrelated package changes in separate branches and PRs.
 - Never split an ebuild change and its `Manifest` update across separate PRs.
 - When rebasing an open PR, prefer `git rebase upstream/master` and push with `--force-with-lease`.
+
+### Completion Reports
+
+- Every completed change must report the topic branch used, upstream remote status, base branch and sync status, files changed, commands run with pass/fail results, checks skipped and why, and any remaining warnings, risks, or limitations.
 
 ## Ebuild Policy
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+English | [简体中文](./README.zh-CN.md)
+
 > [!NOTE]
 > gentoo-zh overlay has moved to https://github.com/gentoo-zh/overlay. Old GitHub URLs continue to redirect. If you manually configured a remote, update it when convenient.
 
@@ -54,6 +56,15 @@ It is recommended to run `pkgdev commit` to quickly generate commit messages.
 
 * I trust contributors that have commit rights, therefore commitors
   should think carefully before committing.
+
+* Generative AI may be used to assist ebuild maintenance, but contributors must
+  ensure the quality of related ebuild changes. In particular, verify functional
+  correctness after modifications; applications, including CLI and GUI
+  applications, should receive appropriate smoke testing through actual use
+  before submission. Even when generative AI is used, the contributor remains
+  the primary person responsible for every commit. The contributor, submitter,
+  and commit author must be a human, not an AI tool or model identity such as
+  Codex, GPT, Claude, Gemini, or similar systems.
 
 * If you are sending a new pull request, make sure it contains all necessary commits
   for a single contribution, e.g. don't send two pull requests for an ebuild and its

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,96 @@
+[English](./README.md) | 简体中文
+
+> [!NOTE]
+> gentoo-zh overlay 已迁移至 https://github.com/gentoo-zh/overlay 。旧的 GitHub URL 会继续重定向。如果你手动配置过 remote，可以在方便时更新。
+
+## 仓库迁移
+
+本仓库通过 GitHub repository transfer 从 `microcai/gentoo-zh` 转移到 `gentoo-zh` 组织，随后又重命名为 `gentoo-zh/overlay`。
+
+当前仓库地址：
+
+https://github.com/gentoo-zh/overlay
+
+详情请参见 [MIGRATION.md](./MIGRATION.md)。
+
+# 如何将此 overlay 添加到 Gentoo 系统
+
+```
+eselect repository enable gentoo-zh
+emaint sync
+```
+
+# 规则一
+
+不要破坏用户的系统。
+
+# 规则二
+
+不要破坏用户的系统。
+
+# 规则三
+
+遵守规则一和规则二。
+
+# 依赖关系表
+
+https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
+
+# 提交信息
+
+建议使用 `pkgdev commit` 快速生成提交信息。
+
+* 对于非版本升级提交，提交信息格式应类似：
+
+        $category/$package: one line short description message
+        {empty line}
+        multiple lines of description about why you change this.
+        if you change to fix the bug, and if there is an GitHub
+        issue entry for that bug, then point the bug link here.
+
+* 对于版本升级提交，提交信息格式应类似：
+
+        $category/$package: add $new_version, drop $old_version
+
+# 贡献
+
+* 我信任拥有提交权限的贡献者，因此提交者在提交前应谨慎确认。
+
+* 可以使用生成式 AI 辅助 ebuild 维护，但贡献者必须确保相关 ebuild
+  修改的质量。尤其要在修改后验证功能正确性；包括 CLI、GUI 等应用形态在内的应用，
+  都应在提交前进行适当的冒烟测试。即便使用生成式 AI 辅助维护，贡献者仍然是每个提交的第一责任人。
+  贡献者、提交者与提交作者必须是人类，不能是 Codex、GPT、Claude、Gemini 等 AI 工具或模型身份，
+  也不能是类似系统。
+
+* 如果你要发起新的 pull request，请确保其中包含单个贡献所需的所有提交，
+  例如不要把一个 ebuild 和它的 `Manifest` 拆成两个 pull request。
+
+* 每个 ebuild 修改在提交前都不应导致编译错误。
+
+* 每个 ebuild 都应在其 `KEYWORDS` 声明的每个 ARCH 上测试。
+  如果没有测试，就不要声称支持该 keyword。
+
+* 每个 ebuild 都应使用 ~arch keywords，不得使用 stable keywords。
+
+* 在打开 pull request 前，请先在本地运行 `pkgcheck scan --commits --net`。
+
+# Distfiles 镜像
+
+我们提供 distfiles 镜像，用于缓存 gentoo-zh 的 distfiles。
+
+我们的服务器托管在美国：
+```
+GENTOO_MIRRORS="${GENTOO_MIRRORS} https://distfiles.gentoozh.org"
+```
+
+重庆大学镜像：
+```
+GENTOO_MIRRORS="${GENTOO_MIRRORS} https://mirrors.cqu.edu.cn/gentoo-zh"
+```
+
+南京大学镜像：
+```
+GENTOO_MIRRORS="${GENTOO_MIRRORS} https://mirrors.nju.edu.cn/gentoo-zh"
+```
+
+# 关于部分无法工作的包，请参见 wiki


### PR DESCRIPTION
## Summary
- Tighten AGENTS.md so all repository modifications are treated as PR-bound work, including automated-agent and automation-assisted changes.
- Add a Simplified Chinese README and language switch links.
- Document AI-assisted ebuild maintenance expectations, human submitter/author requirements, and smoke testing through actual use for applications including CLI and GUI tools.


---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.