### PR TITLE
AGENTS.md: document CI ignore list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ This repository is a Gentoo overlay fork. Prefer generic Gentoo ebuild workflow 
 - Never split an ebuild change and its `Manifest` update across separate PRs.
 - When rebasing an open PR, prefer `git rebase upstream/master` and push with `--force-with-lease`.
 
+### CI Ignore List
+
+- When adding or modifying non-ebuild-related files, check whether `.github/workflows/emerge-on-pr.yml` needs its `ignore_list` updated so those paths do not get interpreted as package atoms for emerge-on-PR testing.
+
 ### Completion Reports
 
 - Every completed change must report the topic branch used, upstream remote status, base branch and sync status, files changed, commands run with pass/fail results, checks skipped and why, and any remaining warnings, risks, or limitations.


### PR DESCRIPTION
Document that non-ebuild-related repository files may need to be added to the emerge-on-PR workflow ignore list.

This helps prevent root-level docs and other non-package paths from being interpreted as package atoms by the PR emerge workflow.

Testing:
- `git diff --check HEAD~1..HEAD`: pass
- `rg -n "^            AGENTS\\.md$|CI Ignore List" AGENTS.md .github/workflows/emerge-on-pr.yml`: pass
- `pkgcheck scan --commits --net`: pass

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
