### PR TITLE
net-proxy/proxy-server: add KEYWORDS, use system openssl and zlib

### DIFF
--- a/net-proxy/proxy-server/proxy-server-11.0.1.ebuild
+++ b/net-proxy/proxy-server/proxy-server-11.0.1.ebuild
@@ -2,6 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
+# every file the cmake<4 compat check flags sits in a third_party test, example or
+# IDE directory that nothing add_subdirectory's. this also hides upstream's own
+# top-level cmake_minimum_required(VERSION 3.5), which has to be fixed upstream
+CMAKE_QA_COMPAT_SKIP=1
+
 inherit cmake
 
 DESCRIPTION="Implementation of all proxy protocols using modern c++"
@@ -9,5 +15,35 @@ HOMEPAGE="https://github.com/jackarain/proxy"
 SRC_URI="https://github.com/Jackarain/proxy/archive/refs/tags/v${PV}.tar.gz -> proxy-${PV}.tar.gz"
 S="${WORKDIR}/proxy-${PV}"
 
-LICENSE="Boost-1.0"
+# MIT covers third_party/fmt, which is built in
+LICENSE="Boost-1.0 MIT"
 SLOT="0"
+KEYWORDS="~amd64"
+
+RDEPEND="
+	dev-libs/openssl:=
+	virtual/zlib:=
+"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	# upstream adds -static-libstdc++ unconditionally and offers no switch for it,
+	# so a libstdc++ ABI fix would never reach the installed binary
+	sed -i -e 's/ -static-libstdc++//g' CMakeLists.txt || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		# upstream vendors openssl and zlib under third_party and builds them by
+		# default; boost and fmt stay bundled, upstream add_subdirectory's them
+		# unconditionally and offers no system switch
+		-DENABLE_SYSTEM_OPENSSL=ON
+		-DENABLE_SYSTEM_ZLIB=ON
+		# a release tarball has no .git, and this would run git in ${S}
+		-DENABLE_GIT_VERSION=OFF
+		-DENABLE_STATIC_LINK_TO_GCC=OFF
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
1. 因为这个 ebuild 从 2024 年加入时就没有 `KEYWORDS`，任何架构都装不上，所以补上 `~amd64`。
2. 因为上游的 `ENABLE_SYSTEM_OPENSSL` 和 `ENABLE_SYSTEM_ZLIB` 默认为 OFF、会改编 `third_party` 下自带的副本，所以打开这两个开关，并把 `dev-libs/openssl` 与 `virtual/zlib` 写进依赖。
3. 因为 release tarball 里没有 `.git`，而默认开启的 `ENABLE_GIT_VERSION` 会在源码树里调用 git，所以关掉它。
4. 因为默认开启的 `ENABLE_STATIC_LINK_TO_GCC` 会静态链接 libgcc，所以关掉它。
5. 因为上游在 GNU 分支无条件追加 `-static-libstdc++` 且没有提供开关，libstdc++ 的 ABI 修正就到不了装好的程序，所以在 `src_prepare` 里去掉这个链接选项。
6. 因为 `third_party/fmt` 被无条件编进程序、许可证是 MIT，所以 `LICENSE` 补上 MIT。

boost 和 fmt 仍然是 bundled：上游的 `add_subdirectory` 无条件执行，也没有 system 开关，boost 那边代码还绑定 `BOOST_ASIO_SEPARATE_COMPILATION` 等定义，换系统库需要改上游。

`CMAKE_QA_COMPAT_SKIP` 跳过的 10 个文件全在 boost 的 test/example/doc、boringssl 的 testdata 和 wolfssl 的 IDE 目录下，没有一个会被 `add_subdirectory`；跳过之后 eclass 也不再补 `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`，照样编得过。代价是上游顶层自己的 `cmake_minimum_required(VERSION 3.5)` 警告一并被压掉，那条得上游改。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
