### PR TITLE
README: fix the Email badge, the mirror link and one PR wording

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,13 +17,13 @@ gentoo-zh is an inclusive overlay.
 
 [![Website](https://img.shields.io/badge/Website-gentoozh.org-54487A?logo=gentoo&logoColor=white)](https://gentoozh.org/en/)
 [![GitHub Issues](https://img.shields.io/badge/GitHub-Issues-181717?logo=github)](https://github.com/gentoo-zh/overlay/issues)
-[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-EA4335?logo=maildotcom&logoColor=white)](mailto:overlay@gentoozh.org)
-[![Forum](https://img.shields.io/badge/Forum-forum.gentoozh.org-000000?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
+[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-000000?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiPjxyZWN0IHg9IjIiIHk9IjQiIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNiIvPjxwYXRoIGQ9Im0yIDYgMTAgNyAxMC03Ii8%2BPC9zdmc%2B)](mailto:overlay@gentoozh.org)
+[![Forum](https://img.shields.io/badge/Forum-forum.gentoozh.org-54487A?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
 [![Wiki](https://img.shields.io/badge/Wiki-Gentoo--zh-54487A?logo=gentoo&logoColor=white)](https://wiki.gentoo.org/wiki/Gentoo-zh)
 [![Telegram group](https://img.shields.io/badge/Telegram%20group-gentoo__zh-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoo_zh)
 [![Announcements](https://img.shields.io/badge/Announcements-gentoocn-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoocn)
 [![Matrix](https://img.shields.io/badge/Matrix-%23gentoo--zh-000000?logo=matrix&logoColor=white)](https://matrix.to/#/%23gentoo-zh:matrix.gentoozh.org)
-[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-5A5A5A?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
+[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-000000?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
 
 For anything about the overlay, GitHub Issues is preferred.
 
@@ -34,7 +34,7 @@ eselect repository enable gentoo-zh
 emaint sync
 ```
 
-Mirrors for mainland China: https://gentoozh.org/en/overlay/
+Mirrors for mainland China: https://gentoozh.org/en/overlay
 
 ## Distfiles and binary packages
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ gentoo-zh 是一个包容的 overlay。
 
 [![官网](https://img.shields.io/badge/%E5%AE%98%E7%BD%91-gentoozh.org-54487A?logo=gentoo&logoColor=white)](https://gentoozh.org/)
 [![GitHub Issues](https://img.shields.io/badge/GitHub-Issues-181717?logo=github)](https://github.com/gentoo-zh/overlay/issues)
-[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-EA4335?logo=maildotcom&logoColor=white)](mailto:overlay@gentoozh.org)
-[![论坛](https://img.shields.io/badge/%E8%AE%BA%E5%9D%9B-forum.gentoozh.org-000000?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
+[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-000000?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiPjxyZWN0IHg9IjIiIHk9IjQiIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNiIvPjxwYXRoIGQ9Im0yIDYgMTAgNyAxMC03Ii8%2BPC9zdmc%2B)](mailto:overlay@gentoozh.org)
+[![论坛](https://img.shields.io/badge/%E8%AE%BA%E5%9D%9B-forum.gentoozh.org-54487A?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
 [![维基](https://img.shields.io/badge/%E7%BB%B4%E5%9F%BA-Gentoo--zh-54487A?logo=gentoo&logoColor=white)](https://wiki.gentoo.org/wiki/Gentoo-zh/zh-cn)
 [![Telegram 群组](https://img.shields.io/badge/%E7%BE%A4%E7%BB%84-gentoo__zh-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoo_zh)
 [![公告频道](https://img.shields.io/badge/%E5%85%AC%E5%91%8A-gentoocn-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoocn)
 [![Matrix](https://img.shields.io/badge/Matrix-%23gentoo--zh-000000?logo=matrix&logoColor=white)](https://matrix.to/#/%23gentoo-zh:matrix.gentoozh.org)
-[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-5A5A5A?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
+[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-000000?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
 
 overlay 相关问题优先使用 GitHub Issues。
 
@@ -34,7 +34,7 @@ eselect repository enable gentoo-zh
 emaint sync
 ```
 
-中国大陆镜像加速相关请参考：https://gentoozh.org/overlay/
+中国大陆镜像加速相关请参考：https://gentoozh.org/overlay
 
 ## distfiles 与二进制包
 
@@ -49,7 +49,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 **不要破坏用户的系统。**
 
 * 我们欢迎所有人贡献，但请提交者在提交前谨慎确认。
-* PR 中的每个提交都要包含所需的所有修改，不要无故拆分，例如 ebuild 和它的 `Manifest` 要在同一个提交里。
+* pull request 中的每个提交都要包含所需的所有修改，不要无故拆分，例如 ebuild 和它的 `Manifest` 要在同一个提交里。
 * 每个 ebuild 修改在提交前要确保编译正确。
 * 新增的软件包需要添加到 [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml) 中，并按照 `category/package` 的字母顺序插入相应位置；如果该软件包不适合使用 nvchecker 检查版本更新，请在对应位置添加注释并说明原因；如果可以自动 bump，参见 [scripts/autobump.zh.md](./scripts/autobump.zh.md)。
 * 在打开 pull request 前，请先在本地运行 `pkgcheck scan --commits --net`。

--- a/README.zh-HK.md
+++ b/README.zh-HK.md
@@ -17,13 +17,13 @@ gentoo-zh 係一個包容嘅 overlay。
 
 [![官網](https://img.shields.io/badge/%E5%AE%98%E7%B6%B2-gentoozh.org-54487A?logo=gentoo&logoColor=white)](https://gentoozh.org/zh-tw/)
 [![GitHub Issues](https://img.shields.io/badge/GitHub-Issues-181717?logo=github)](https://github.com/gentoo-zh/overlay/issues)
-[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-EA4335?logo=maildotcom&logoColor=white)](mailto:overlay@gentoozh.org)
-[![論壇](https://img.shields.io/badge/%E8%AB%96%E5%A3%87-forum.gentoozh.org-000000?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
+[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-000000?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiPjxyZWN0IHg9IjIiIHk9IjQiIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNiIvPjxwYXRoIGQ9Im0yIDYgMTAgNyAxMC03Ii8%2BPC9zdmc%2B)](mailto:overlay@gentoozh.org)
+[![論壇](https://img.shields.io/badge/%E8%AB%96%E5%A3%87-forum.gentoozh.org-54487A?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
 [![維基](https://img.shields.io/badge/%E7%B6%AD%E5%9F%BA-Gentoo--zh-54487A?logo=gentoo&logoColor=white)](https://wiki.gentoo.org/wiki/Gentoo-zh)
 [![Telegram 群組](https://img.shields.io/badge/%E7%BE%A4%E7%B5%84-gentoo__zh-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoo_zh)
 [![公告頻道](https://img.shields.io/badge/%E5%85%AC%E5%91%8A-gentoocn-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoocn)
 [![Matrix](https://img.shields.io/badge/Matrix-%23gentoo--zh-000000?logo=matrix&logoColor=white)](https://matrix.to/#/%23gentoo-zh:matrix.gentoozh.org)
-[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-5A5A5A?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
+[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-000000?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
 
 overlay 相關問題優先使用 GitHub Issues。
 
@@ -34,7 +34,7 @@ eselect repository enable gentoo-zh
 emaint sync
 ```
 
-中國大陸鏡像加速相關請睇：https://gentoozh.org/zh-tw/overlay/
+中國大陸鏡像加速相關請睇：https://gentoozh.org/zh-tw/overlay
 
 ## distfiles 同二進制軟件包
 
@@ -49,7 +49,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 **唔好整爛人哋個系統。**
 
 * 我哋歡迎所有人貢獻，不過請提交者喺提交之前小心確認清楚。
-* PR 入面每個提交都要包含所需嘅全部修改，唔好無故拆開，例如 ebuild 同佢個 `Manifest` 要擺喺同一個提交入面。
+* pull request 入面每個提交都要包含所需嘅全部修改，唔好無故拆開，例如 ebuild 同佢個 `Manifest` 要擺喺同一個提交入面。
 * 每個 ebuild 改動喺提交之前要確保編譯得到。
 * 新加嘅軟件包要加入 [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml)，按 `category/package` 嘅字母順序擺入對應位置；如果嗰個軟件包唔適合用 nvchecker 檢查版本更新，就喺對應位置加返個註釋講清楚點解；如果可以自動 bump，請睇 [scripts/autobump.zh.md](./scripts/autobump.zh.md)。
 * 開 pull request 之前，請先喺本地跑 `pkgcheck scan --commits --net`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -17,13 +17,13 @@ gentoo-zh 是一個包容的 overlay。
 
 [![官網](https://img.shields.io/badge/%E5%AE%98%E7%B6%B2-gentoozh.org-54487A?logo=gentoo&logoColor=white)](https://gentoozh.org/zh-tw/)
 [![GitHub Issues](https://img.shields.io/badge/GitHub-Issues-181717?logo=github)](https://github.com/gentoo-zh/overlay/issues)
-[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-EA4335?logo=maildotcom&logoColor=white)](mailto:overlay@gentoozh.org)
-[![論壇](https://img.shields.io/badge/%E8%AB%96%E5%A3%87-forum.gentoozh.org-000000?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
+[![Email](https://img.shields.io/badge/Email-overlay%40gentoozh.org-000000?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiPjxyZWN0IHg9IjIiIHk9IjQiIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNiIvPjxwYXRoIGQ9Im0yIDYgMTAgNyAxMC03Ii8%2BPC9zdmc%2B)](mailto:overlay@gentoozh.org)
+[![論壇](https://img.shields.io/badge/%E8%AB%96%E5%A3%87-forum.gentoozh.org-54487A?logo=discourse&logoColor=white)](https://forum.gentoozh.org/)
 [![維基](https://img.shields.io/badge/%E7%B6%AD%E5%9F%BA-Gentoo--zh-54487A?logo=gentoo&logoColor=white)](https://wiki.gentoo.org/wiki/Gentoo-zh)
 [![Telegram 群組](https://img.shields.io/badge/%E7%BE%A4%E7%B5%84-gentoo__zh-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoo_zh)
 [![公告頻道](https://img.shields.io/badge/%E5%85%AC%E5%91%8A-gentoocn-26A5E4?logo=telegram&logoColor=white)](https://t.me/gentoocn)
 [![Matrix](https://img.shields.io/badge/Matrix-%23gentoo--zh-000000?logo=matrix&logoColor=white)](https://matrix.to/#/%23gentoo-zh:matrix.gentoozh.org)
-[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-5A5A5A?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
+[![IRC](https://img.shields.io/badge/IRC-%23gentoo--zh-000000?logo=liberadotchat&logoColor=white)](https://web.libera.chat/#gentoo-zh)
 
 overlay 相關問題優先使用 GitHub Issues。
 
@@ -34,7 +34,7 @@ eselect repository enable gentoo-zh
 emaint sync
 ```
 
-中國大陸鏡像加速相關請參考：https://gentoozh.org/zh-tw/overlay/
+中國大陸鏡像加速相關請參考：https://gentoozh.org/zh-tw/overlay
 
 ## distfiles 與二進位套件
 
@@ -49,7 +49,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 **不要破壞使用者的系統。**
 
 * 我們歡迎所有人貢獻，但請提交者在提交前謹慎確認。
-* PR 中的每個提交都要包含所需的所有修改，不要無故拆分，例如 ebuild 和它的 `Manifest` 要在同一個提交裡。
+* pull request 中的每個提交都要包含所需的所有修改，不要無故拆分，例如 ebuild 和它的 `Manifest` 要在同一個提交裡。
 * 每個 ebuild 修改在提交前要確保編譯正確。
 * 新增的套件需要加入 [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml)，並按照 `category/package` 的字母順序插入相應位置；如果該套件不適合使用 nvchecker 檢查版本更新，請在對應位置加上註解並說明原因；如果可以自動 bump，參見 [scripts/autobump.zh.md](./scripts/autobump.zh.md)。
 * 在開啟 pull request 前，請先在本機執行 `pkgcheck scan --commits --net`。


### PR DESCRIPTION
三处小修：

- Email 徽章挂的是 mail.com 的 m 字标，底色是 Gmail 红，`overlay@gentoozh.org` 两家都不是。换成普通信封，SVG 以 data URI 内嵌，底色改成和 IRC 徽章一样的灰。
- 镜像页链接的尾斜线去掉，带斜线只会多一次 307。
- 一条规则写的是 PR，其他地方都写 pull request，统一。

组织首页的同一处徽章改动在 gentoo-zh/.github#4。