### PR TITLE
mirror-to-codeberg.yml: restrict when the mirror runs

### DIFF
--- a/.github/workflows/mirror-to-codeberg.yml
+++ b/.github/workflows/mirror-to-codeberg.yml
@@ -2,6 +2,8 @@ name: mirror to codeberg
 on:
   workflow_dispatch:
   push:
+    branches: [master]
+    tags: ['**']
   delete:
   schedule:
     - cron: '40 4 * * *'
@@ -12,7 +14,7 @@ concurrency:
 jobs:
   mirror:
     runs-on: ubuntu-latest
-    if: github.repository == 'gentoo-zh/overlay'
+    if: github.repository == 'gentoo-zh/overlay' && github.actor != 'dependabot[bot]'
     steps:
     - name: Clone GitHub repository (bare mirror)
       run: git clone --mirror "https://github.com/${GITHUB_REPOSITORY}.git" repo.git


### PR DESCRIPTION
因为 GitHub 不向 Dependabot 触发的运行提供仓库 secrets，`CODEBERG_SSH_KEY` 取到空值、推送必定失败，所以跳过 Dependabot 的运行。

因为这个 workflow 每次都 `git clone --mirror` 整个仓库并推送全部 ref，一次运行就已同步所有分支，所以 push 只在 master 和 tag 上触发。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
