### PR TITLE
.github/workflows: nvchecker: track tencent-qq by regex

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1910,9 +1910,9 @@ regex = 'com.alibabainc.dingtalk_(.*)_amd64.deb'
 github_account = "gouwazi"
 
 ["net-im/tencent-qq"]
-source = "jq"
+source = "regex"
 url = "https://qq-web.cdn-go.cn/im.qq.com_new/latest/rainbow/pcConfig.json"
-filter = ".Linux.version"
+regex = '"Linux":\s*\{\s*"version":\s*"([\d.]+)"'
 github_account = ["Puqns67", "gouwazi"]
 
 ["net-im/vesktop-bin"]


### PR DESCRIPTION
因为 `source = "jq"` 把整个条目当作缓存键，`github_account` 的列表值不可散列、查找时抛 TypeError，所以改用只按自身栏位组键的 `regex` 来源。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
