### PR TITLE
profiles: add license_groups for this repository's licenses

### DIFF
--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -1,0 +1,14 @@
+# Groups for the licenses this repository carries. Portage merges these with the
+# ones the master repository defines, so each line lists only our own additions.
+
+# Each of these either forbids redistributing the software, restricts what the
+# redistributor may charge, or requires the licensor's written permission.
+EULA AdsPower-EULA Anthropic BaiduNetDisk Bcompare CAJVIEWER-EULA cursor Feishu-EULA Google-TOS harmonoid-EULA HarmonyOS-Sans JetBrainsToolbox JLC-EULA Kiro LCEDA-EULA MiSans NFTC Obsidian-EULA openclaude reqable_license SINEW-EULA SoftMaker Source-SDK Tencent tenvideo-privacy termius todesk trae typora unity-EULA VESTA wemeet_license windsurf
+
+# Free, but not listed by the FSF or the OSI: redistribution and modification
+# are granted, subject to keeping the copyright notice and not reusing the name.
+MISC-FREE Programmer-Dvorak
+
+# Redistributing the unmodified table carries no cost limit and needs no
+# permission; only re-encoding it and then redistributing is denied.
+BINARY-REDISTRIBUTABLE dayi


### PR DESCRIPTION
因为本仓库自带的 35 个授权不属于任何 license group，使用者在预设的 `ACCEPT_LICENSE="-* @FREE"` 下只能逐个点名才装得上，所以按各自的散布条款归入 `@EULA` 与 `@BINARY-REDISTRIBUTABLE`。Portage 会把这里的定义与主仓库的同名分组合并。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
