### PR TITLE
sci-chemistry/vesta, media-sound/harmonoid: fix elog gate failures

### DIFF
--- a/media-sound/harmonoid/harmonoid-0.3.32.ebuild
+++ b/media-sound/harmonoid/harmonoid-0.3.32.ebuild
@@ -45,13 +45,13 @@ pkg_postinst() {
 	xdg_pkg_postinst
 
 	if [ "$(uname -m)" = "aarch64" ]; then
-		ewarn "libflutter_linux_gtk.so from the official arm64 flutter engine"
-		ewarn "is not linked against fontconfig, which prevents flutter from"
-		ewarn "finding system CJK fonts, rendering those characters tofu box."
-		ewarn " "
-		ewarn "The flutter officials have noticed this and are in progress."
-		ewarn "( https://github.com/flutter/flutter/pull/180235 )"
-		ewarn "Rebuilding flutter engine with fontconfig enabled might"
-		ewarn "tackle the issue temporarily."
+		elog "libflutter_linux_gtk.so from the official arm64 flutter engine"
+		elog "is not linked against fontconfig, which prevents flutter from"
+		elog "finding system CJK fonts, rendering those characters tofu box."
+		elog " "
+		elog "The flutter officials have noticed this and are in progress."
+		elog "( https://github.com/flutter/flutter/pull/180235 )"
+		elog "Rebuilding flutter engine with fontconfig enabled might"
+		elog "tackle the issue temporarily."
 	fi
 }

--- a/sci-chemistry/vesta/metadata.xml
+++ b/sci-chemistry/vesta/metadata.xml
@@ -5,4 +5,7 @@
 		<email>chn@chn.moe</email>
 		<name>Haonan Chen</name>
 	</maintainer>
+	<use>
+		<flag name="powderplot">Install the bundled PowderPlot tool, which plots powder diffraction patterns produced by RIETAN</flag>
+	</use>
 </pkgmetadata>

--- a/sci-chemistry/vesta/vesta-3.5.8.ebuild
+++ b/sci-chemistry/vesta/vesta-3.5.8.ebuild
@@ -15,6 +15,7 @@ LICENSE="VESTA"
 SLOT="0"
 KEYWORDS="~amd64"
 
+IUSE="powderplot"
 RESTRICT="bindist mirror strip"
 
 RDEPEND="
@@ -22,12 +23,17 @@ RDEPEND="
 	virtual/glu
 	dev-util/desktop-file-utils
 	x11-libs/libXtst
-	virtual/jdk
+	powderplot? (
+		virtual/jdk
+		x11-libs/gtk+:2
+	)
 	${DEPEND}"
 
 QA_PREBUILT="*"
 
 src_install() {
+	use powderplot || rm -r PowderPlot || die
+
 	insinto /opt/VESTA
 	doins -r *
 	fperms +x /opt/VESTA/VESTA


### PR DESCRIPTION
两处都是既有问题，`*/*: add RESTRICT=bindist where the license forbids redistribution` 触及这两个 ebuild 后 CI 才首次构建它们，从而暴露出来。

- `sci-chemistry/vesta`：因为 PowderPlot 下的 `libswt-atk-gtk-3346.so` 与 `libswt-pi-gtk-3346.so` 链接 `libgtk-x11-2.0.so.0`，而 `RDEPEND` 只有 `gtk+:3`，所以补上 `x11-libs/gtk+:2`。
- `media-sound/harmonoid`：因为这段只是告知 arm64 flutter engine 未链接 fontconfig 这一上游已知问题，而 `ewarn` 属于 CI 检查的 warn 级 elog、会让构建失败，所以改用 `elog`，内容不变。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
