### PR TITLE
*/*: complete RESTRICT for packages whose license forbids redistribution

### DIFF
--- a/app-editors/typora/typora-0.11.18.ebuild
+++ b/app-editors/typora/typora-0.11.18.ebuild
@@ -15,7 +15,7 @@ LICENSE="typora"
 SLOT="0"
 KEYWORDS="-* ~amd64"
 
-RESTRICT="mirror"
+RESTRICT="mirror bindist"
 
 RDEPEND="x11-libs/libXScrnSaver"
 

--- a/app-editors/typora/typora-1.14.8.ebuild
+++ b/app-editors/typora/typora-1.14.8.ebuild
@@ -14,7 +14,7 @@ LICENSE="typora"
 SLOT="0"
 KEYWORDS="~amd64"
 
-RESTRICT="mirror splitdebug"
+RESTRICT="mirror splitdebug bindist"
 
 RDEPEND="
 	app-accessibility/at-spi2-core:2

--- a/app-misc/bcompare/bcompare-4.4.6.27483.ebuild
+++ b/app-misc/bcompare/bcompare-4.4.6.27483.ebuild
@@ -13,7 +13,7 @@ LICENSE="Bcompare"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-RESTRICT="bindist"
+RESTRICT="bindist mirror"
 
 # qt4
 #	libQtCore.so.4

--- a/app-misc/bcompare/bcompare-4.4.7.28397.ebuild
+++ b/app-misc/bcompare/bcompare-4.4.7.28397.ebuild
@@ -13,7 +13,7 @@ LICENSE="Bcompare"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-RESTRICT="bindist"
+RESTRICT="bindist mirror"
 
 # qt4
 #	libQtCore.so.4

--- a/app-misc/bcompare/bcompare-5.2.4.32425.ebuild
+++ b/app-misc/bcompare/bcompare-5.2.4.32425.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	x11-libs/libxkbcommon
 "
 
-RESTRICT="bindist strip"
+RESTRICT="bindist strip mirror"
 
 # Optional shell extensions are installed for KDE/Qt versions not required by the main app.
 REQUIRES_EXCLUDE="

--- a/app-misc/cherry-studio-bin/cherry-studio-bin-1.9.12-r1.ebuild
+++ b/app-misc/cherry-studio-bin/cherry-studio-bin-1.9.12-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 
 BDEPEND="arm64? ( dev-util/patchelf )"
 
-RESTRICT="strip"
+RESTRICT="strip bindist mirror"
 
 src_unpack() {
 	if use amd64; then

--- a/app-office/freeoffice/freeoffice-1062.ebuild
+++ b/app-office/freeoffice/freeoffice-1062.ebuild
@@ -20,7 +20,7 @@ for lang in ${LANGUAGES}; do
 	IUSE+="l10n_${lang%:*} "
 done
 
-RESTRICT="mirror strip"
+RESTRICT="mirror strip bindist"
 
 DEPEND="
 	app-admin/chrpath

--- a/app-office/freeoffice/freeoffice-1064.ebuild
+++ b/app-office/freeoffice/freeoffice-1064.ebuild
@@ -20,7 +20,7 @@ for lang in ${LANGUAGES}; do
 	IUSE+="l10n_${lang%:*} "
 done
 
-RESTRICT="mirror strip"
+RESTRICT="mirror strip bindist"
 
 DEPEND="
 	app-admin/chrpath

--- a/app-office/freeoffice/freeoffice-1068.ebuild
+++ b/app-office/freeoffice/freeoffice-1068.ebuild
@@ -20,7 +20,7 @@ for lang in ${LANGUAGES}; do
 	IUSE+="l10n_${lang%:*} "
 done
 
-RESTRICT="mirror strip"
+RESTRICT="mirror strip bindist"
 
 DEPEND="
 	app-admin/chrpath

--- a/app-office/freeoffice/freeoffice-1220.ebuild
+++ b/app-office/freeoffice/freeoffice-1220.ebuild
@@ -20,7 +20,7 @@ for lang in ${LANGUAGES}; do
 	IUSE+="l10n_${lang%:*} "
 done
 
-RESTRICT="mirror strip"
+RESTRICT="mirror strip bindist"
 
 DEPEND="
 	app-admin/chrpath

--- a/app-office/freeoffice/freeoffice-1234.ebuild
+++ b/app-office/freeoffice/freeoffice-1234.ebuild
@@ -20,7 +20,7 @@ for lang in ${LANGUAGES}; do
 	IUSE+="l10n_${lang%:*} "
 done
 
-RESTRICT="mirror strip"
+RESTRICT="mirror strip bindist"
 
 BDEPEND="
 	app-admin/chrpath

--- a/dev-util/jetbrains-toolbox/jetbrains-toolbox-3.6.3.86383.ebuild
+++ b/dev-util/jetbrains-toolbox/jetbrains-toolbox-3.6.3.86383.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	sys-fs/fuse:0
 "
 
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 QA_PREBUILT="/opt/${PN}/${PN}"
 

--- a/dev-util/trae-ide/trae-ide-2.3.62837.ebuild
+++ b/dev-util/trae-ide/trae-ide-2.3.62837.ebuild
@@ -58,7 +58,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
 
-RESTRICT="mirror"
+RESTRICT="mirror bindist"
 
 QA_PREBUILT="/usr/share/trae-cn/*"
 # prebuilt Electron/sandbox blobs (sbox.so, crashpad_handler, bwrap, bundled .so) ship

--- a/games-fps/source-engine/source-engine-9999.ebuild
+++ b/games-fps/source-engine/source-engine-9999.ebuild
@@ -15,6 +15,7 @@ EGIT_REPO_URI="https://github.com/nillerusr/source-engine.git"
 LICENSE="Source-SDK"
 SLOT="0"
 IUSE="debug"
+RESTRICT="bindist"
 BDEPEND="${PYTHON_DEPS}
 		 media-libs/libsdl2
 		 media-libs/freetype

--- a/media-video/tenvideo/tenvideo-1.0.10.ebuild
+++ b/media-video/tenvideo/tenvideo-1.0.10.ebuild
@@ -14,7 +14,7 @@ LICENSE="tenvideo-privacy"
 SLOT="0"
 KEYWORDS="~amd64"
 
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	app-accessibility/at-spi2-core

--- a/net-im/tencent-qq/tencent-qq-3.2.32.ebuild
+++ b/net-im/tencent-qq/tencent-qq-3.2.32.ebuild
@@ -27,7 +27,7 @@ KEYWORDS="-* ~amd64 ~arm64"
 
 IUSE="bwrap system-fdk-aac system-libssh2 system-openh264 system-zlib gnome"
 
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	app-accessibility/at-spi2-core:2

--- a/net-misc/baidunetdisk/baidunetdisk-8.5.2-r1.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-8.5.2-r1.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 LICENSE="BaiduNetDisk"
 SLOT="0"
 KEYWORDS="-* ~amd64"
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	app-crypt/p11-kit

--- a/net-misc/baidunetdisk/baidunetdisk-8.5.2.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-8.5.2.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 LICENSE="BaiduNetDisk"
 SLOT="0"
 KEYWORDS="-* ~amd64"
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	app-crypt/p11-kit

--- a/net-misc/baidunetdisk/baidunetdisk-8.6.0.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-8.6.0.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}"
 LICENSE="BaiduNetDisk"
 SLOT="0"
 KEYWORDS="-* ~amd64"
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	app-crypt/p11-kit

--- a/net-misc/reqable/reqable-3.2.17.ebuild
+++ b/net-misc/reqable/reqable-3.2.17.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	x11-libs/gtk+:3
 "
 
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 src_install() {
 	insinto /usr/share/reqable

--- a/net-misc/todesk/todesk-4.8.6.2.ebuild
+++ b/net-misc/todesk/todesk-4.8.6.2.ebuild
@@ -14,7 +14,7 @@ LICENSE="todesk"
 SLOT="0"
 KEYWORDS="-* ~amd64"
 IUSE="systemd"
-RESTRICT="strip mirror"
+RESTRICT="strip mirror bindist"
 
 RDEPEND="
 	dev-libs/nspr

--- a/sci-electronics/jlc-assistant-bin/jlc-assistant-bin-5.0.69.ebuild
+++ b/sci-electronics/jlc-assistant-bin/jlc-assistant-bin-5.0.69.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${MY_PN}-linux-x64-${PV}"
 LICENSE="JLC-EULA"
 SLOT="0"
 KEYWORDS="~amd64"
-RESTRICT="splitdebug mirror"
+RESTRICT="splitdebug mirror bindist"
 
 RDEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0:2

--- a/sci-electronics/lceda-pro/lceda-pro-3.2.175.ebuild
+++ b/sci-electronics/lceda-pro/lceda-pro-3.2.175.ebuild
@@ -50,7 +50,7 @@ DEPEND="
 	"
 RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
-RESTRICT="mirror"
+RESTRICT="mirror bindist"
 
 QA_PREBUILT="
 	/opt/lceda-pro/chrome-sandbox

--- a/sci-electronics/lceda/lceda-6.5.51.ebuild
+++ b/sci-electronics/lceda/lceda-6.5.51.ebuild
@@ -48,7 +48,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
 
-RESTRICT="mirror"
+RESTRICT="mirror bindist"
 
 QA_PREBUILT="
 	/opt/lceda/swiftshader/libEGL.so


### PR DESCRIPTION
因为这些包的授权或是禁止再散布软件本体、或是禁止对散布收取费用、或是要求授权方书面同意，而它们的 `RESTRICT` 缺少 `bindist`（`app-misc/bcompare` 缺 `mirror`），构建出的二进制包与 distfile 会被当作可以散布，所以按各自的条款补齐。

条款依据（逐字核对，非推断）：

- `Bcompare`：允许「give exact, unmodified copies of the Software to anyone」，但「You are specifically prohibited from charging any fees for any such copies or distributions.」
- `NFTC`：允许「redistribute the unmodified Program」，但「provided that You do not charge Your licensees any fees associated with such distribution」
- `Source-SDK`：「You may copy, modify, and distribute the SDK ... but only for free.」
- `typora`：「You shall not: rent, lease, lend, sell, redistribute ...」，其 Linux repackage 例外只解除打包限制，未解除散布与销售禁令
- 其余（`BaiduNetDisk`、`Tencent`、`todesk`、`LCEDA-EULA`、`JLC-EULA`、`SoftMaker`、`JetBrainsToolbox`、`reqable_license`、`tenvideo-privacy`、`Cherry-Studio`）均要求授权方书面同意后方可散布

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
