### PR TITLE
app-i18n/fcitx-kkc, app-i18n/fcitx-skk: allow fcitx-qt without qt6

### DIFF
--- a/app-i18n/fcitx-kkc/fcitx-kkc-5.1.10.ebuild
+++ b/app-i18n/fcitx-kkc/fcitx-kkc-5.1.10.ebuild
@@ -20,7 +20,7 @@ IUSE="+qt6"
 RDEPEND="
 	>=app-i18n/fcitx-5.1.13:5
 	app-i18n/libkkc
-	qt6? ( app-i18n/fcitx-qt:5[qt6] )
+	qt6? ( app-i18n/fcitx-qt:5[qt6(+)] )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="

--- a/app-i18n/fcitx-skk/fcitx-skk-5.1.7-r2.ebuild
+++ b/app-i18n/fcitx-skk/fcitx-skk-5.1.7-r2.ebuild
@@ -19,7 +19,7 @@ IUSE="qt6"
 
 RDEPEND="
 	>=app-i18n/fcitx-5.1.13:5
-	app-i18n/fcitx-qt[qt6?,-onlyplugin]
+	app-i18n/fcitx-qt[qt6(+)?,-onlyplugin]
 	app-i18n/libskk
 	app-i18n/skk-jisyo
 	qt6? (


### PR DESCRIPTION
因为 `app-i18n/fcitx-qt-5.1.14` 只支持 Qt6、已移除 `qt6` USE 标志，而这两处 use dep 没有写 `(+)` 默认值，会把 `fcitx-qt` 钉在 5.1.12：

```
!!! Multiple package instances within a single package slot ... slot conflict:
  (app-i18n/fcitx-qt-5.1.12-1:5/5::gentoo) pulled in by
    app-i18n/fcitx-qt:5[qt6] required by (app-i18n/fcitx-kkc-5.1.10:5/5::gentoo-zh)
                        ^^^
```

装了 fcitx-kkc 或 fcitx-skk-5.1.7-r2 的使用者因此升不了 fcitx-qt。仓库里其余五处引用早已写成 `qt6(+)`，这两处是遗漏。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
