### PR TITLE
README: require contributors to get the license right

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -55,6 +55,10 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
   change across commits without reason, e.g. an ebuild and its `Manifest` belong in
   the same commit.
 * Every ebuild change must compile before committing.
+* `LICENSE` must match what upstream actually grants. When the license is not in
+  `::gentoo`, add its full text under [`licenses/`](./licenses), put it in the matching
+  group in [`profiles/license_groups`](./profiles/license_groups), and set `RESTRICT`
+  from its redistribution terms.
 * A new package must be added to
   [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml), inserted in
   alphabetical order by `category/package`; if it is not suitable for nvchecker to

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 * 我们欢迎所有人贡献，但请提交者在提交前谨慎确认。
 * pull request 中的每个提交都要包含所需的所有修改，不要无故拆分，例如 ebuild 和它的 `Manifest` 要在同一个提交里。
 * 每个 ebuild 修改在提交前要确保编译正确。
+* `LICENSE` 要与上游实际授权一致。授权不在 `::gentoo` 时把全文放进 [`licenses/`](./licenses)，归入 [`profiles/license_groups`](./profiles/license_groups) 的相应分组，并按其散布条款设置 `RESTRICT`。
 * 新增的软件包需要添加到 [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml) 中，并按照 `category/package` 的字母顺序插入相应位置；如果该软件包不适合使用 nvchecker 检查版本更新，请在对应位置添加注释并说明原因；如果可以自动 bump，参见 [scripts/autobump.zh.md](./scripts/autobump.zh.md)。
 * 在打开 pull request 前，请先在本地运行 `pkgcheck scan --commits --net`。
 * 开 pull request 之后，请检查并修正 pkgcheck report 和 CI 报出的错误，QA 提示也要处理。

--- a/README.zh-HK.md
+++ b/README.zh-HK.md
@@ -51,6 +51,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 * 我哋歡迎所有人貢獻，不過請提交者喺提交之前小心確認清楚。
 * pull request 入面每個提交都要包含所需嘅全部修改，唔好無故拆開，例如 ebuild 同佢個 `Manifest` 要擺喺同一個提交入面。
 * 每個 ebuild 改動喺提交之前要確保編譯得到。
+* `LICENSE` 要同上游實際授權一致。授權唔喺 `::gentoo` 嘅時候，將全文放入 [`licenses/`](./licenses)，歸入 [`profiles/license_groups`](./profiles/license_groups) 嘅相應分組，並按佢嘅散布條款設定 `RESTRICT`。
 * 新加嘅軟件包要加入 [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml)，按 `category/package` 嘅字母順序擺入對應位置；如果嗰個軟件包唔適合用 nvchecker 檢查版本更新，就喺對應位置加返個註釋講清楚點解；如果可以自動 bump，請睇 [scripts/autobump.zh.md](./scripts/autobump.zh.md)。
 * 開 pull request 之前，請先喺本地跑 `pkgcheck scan --commits --net`。
 * 開 pull request 之後，請檢查同修正 pkgcheck report 同 CI 報出嘅錯誤，QA 提示都要處理。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -51,6 +51,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 * 我們歡迎所有人貢獻，但請提交者在提交前謹慎確認。
 * pull request 中的每個提交都要包含所需的所有修改，不要無故拆分，例如 ebuild 和它的 `Manifest` 要在同一個提交裡。
 * 每個 ebuild 修改在提交前要確保編譯正確。
+* `LICENSE` 要與上游實際授權一致。授權不在 `::gentoo` 時把全文放進 [`licenses/`](./licenses)，歸入 [`profiles/license_groups`](./profiles/license_groups) 的相應分組，並按其散布條款設定 `RESTRICT`。
 * 新增的套件需要加入 [`.github/workflows/overlay.toml`](./.github/workflows/overlay.toml)，並按照 `category/package` 的字母順序插入相應位置；如果該套件不適合使用 nvchecker 檢查版本更新，請在對應位置加上註解並說明原因；如果可以自動 bump，參見 [scripts/autobump.zh.md](./scripts/autobump.zh.md)。
 * 在開啟 pull request 前，請先在本機執行 `pkgcheck scan --commits --net`。
 * 開 pull request 之後，請檢查並修正 pkgcheck report 和 CI 報出的錯誤，QA 提示也要處理。


### PR DESCRIPTION
因为这一轮核对全部软件包后发现 42 个的 `LICENSE` 与上游不符、三个授权文件装的不是授权条款（`unity-EULA` 是隐私政策、`CAJVIEWER-EULA` 只有第三方版权致谢、`dev-util/trae-ide` 用的是嘉立创 EDA 的协议）、十九个软件包漏了按条款该有的 `RESTRICT`，而贡献指南对此没有任何要求，所以补上一条。

`ACCEPT_LICENSE` 属于 Gentoo 自身的机制、官方文档已有说明，不在此重复。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
