### PR TITLE
generate-deps-relation-r1.yml: skip on forks

### DIFF
--- a/.github/workflows/generate-deps-relation-r1.yml
+++ b/.github/workflows/generate-deps-relation-r1.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate:
+    if: github.repository == 'gentoo-zh/overlay' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
这个 job 会 checkout deps-table 分支,而这个分支只有 gentoo-zh/overlay 有,所以每个 fork 同步 master 都会失败一次。

其他几个定时 workflow(nvchecker、mirror-to-codeberg、autobump)已经有同样的 github.repository 判断,这里是漏的。带上 workflow_dispatch,fork 里还能手动跑。

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
