### PR TITLE
scripts/autobump-sweep.sh: print the engine's full output on failure

### DIFF
--- a/scripts/autobump-sweep.sh
+++ b/scripts/autobump-sweep.sh
@@ -165,7 +165,13 @@ for n in "${ISSUES[@]}"; do
     echo "==== #$n $pkg -> $ver ($attempts/$LIMIT) ===="
     status_comment "$n" "**autobump** is bumping \`$pkg\` → \`$ver\`…$(run_link)"
     out=$($ENGINE "$n" $KEEP_OLD $PR 2>&1); ec=$?
-    echo "$out" | tail -4
+    # on success the tail is enough. on failure print everything: the engine's evidence dir is
+    # inside the CI container and dies with it, so this log is the only postmortem material left.
+    if [ "$ec" = 0 ]; then
+        echo "$out" | tail -4
+    else
+        echo "$out"
+    fi
 
     case "$ec" in
     0)


### PR DESCRIPTION
失败时只印最后 4 行,引擎的 evidence 目录又在 CI 容器里跟着没了,一个失败的 bump 什么都不剩。改成失败时打印完整输出。

`bash -n` 过。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
