### PR TITLE
app-i18n/fcitx-table-dayi: restrict binary redistribution

### DIFF
--- a/app-i18n/fcitx-table-dayi/fcitx-table-dayi-9999.ebuild
+++ b/app-i18n/fcitx-table-dayi/fcitx-table-dayi-9999.ebuild
@@ -14,6 +14,7 @@ EGIT_REPO_URI="https://github.com/fcitx/fcitx5-table-dayi.git"
 LICENSE="dayi"
 SLOT="5"
 KEYWORDS=""
+RESTRICT="bindist"
 
 DEPEND="
 	app-i18n/fcitx:5

--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -11,4 +11,4 @@ MISC-FREE Programmer-Dvorak
 
 # Binary redistribution needs no permission. The two LCEDA files grant it only
 # as a pair, so the EULA is here and not in @EULA.
-BINARY-REDISTRIBUTABLE dayi LCEDA-Distribution-License LCEDA-Software-EULA
+BINARY-REDISTRIBUTABLE LCEDA-Distribution-License LCEDA-Software-EULA


### PR DESCRIPTION
因為 `dayi` 授權沒有明確授予公開再散布未修改內容的權利，所以從 `BINARY-REDISTRIBUTABLE` 移除並設定 `RESTRICT=bindist`。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.