### PR TITLE
net-misc/apifox: fix description and redistribution restriction

### DIFF
--- a/net-misc/apifox/apifox-2.8.41.ebuild
+++ b/net-misc/apifox/apifox-2.8.41.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop xdg unpacker
 
-DESCRIPTION="API 文档、API 调试、API Mock、API 自动化测试"
+DESCRIPTION="Platform for API design, debugging, testing, and documentation"
 HOMEPAGE="https://apifox.com/"
 SRC_URI="
 	amd64? ( https://file-assets.apifox.com/download/Apifox-linux-latest.zip -> ${P}-amd64.zip )
@@ -17,7 +17,7 @@ LICENSE="all-rights-reserved"
 SLOT="0"
 KEYWORDS="~amd64"
 
-RESTRICT="strip mirror"
+RESTRICT="bindist mirror strip"
 
 RDEPEND="sys-fs/fuse:0"
 BDEPEND="app-arch/unzip"


### PR DESCRIPTION
因為 `all-rights-reserved` 不允許再散布，所以設定 `RESTRICT=bindist`。

因為 `DESCRIPTION` 是通用 metadata，所以改用英文套件描述。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.