### PR TITLE
overlay.toml: track mkinitcpio Arch package

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2548,11 +2548,9 @@ to_pattern = "\\1"
 github_account = ["zozx", "gouwazi"]
 
 ["sys-kernel/mkinitcpio"]
-source = "gitlab"
-host = "gitlab.archlinux.org"
-gitlab = "archlinux/mkinitcpio/mkinitcpio"
-use_max_tag = true
-prefix = "v"
+source = "archpkg"
+archpkg = "mkinitcpio"
+strip_release = true
 
 # xanmod-kernel and xanmod-sources track the same repo (xanmod/linux) and are
 # always bumped together, so track only the source xanmod-sources.


### PR DESCRIPTION
因为 GitLab tag 和 Arch packaging 仓库会早于正式仓库包发布，所以改用 Arch package version，避免在可安装版本和 release tarball 尚未发布时创建 bump issue。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
