### PR TITLE
media-fonts/nerd-fonts: add 3.5.0-r1, drop 3.5.0

### DIFF
--- a/media-fonts/nerd-fonts/nerd-fonts-3.5.0-r1.ebuild
+++ b/media-fonts/nerd-fonts/nerd-fonts-3.5.0-r1.ebuild
@@ -168,7 +168,7 @@ LICENSE="MIT
 		BitstreamVera
 		BSD
 		WTFPL-2
-		Vic-Fieger-License
+		heavydata? ( Vic-Fieger-License )
 		UbuntuFontLicense-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~loong ~x86"
@@ -180,6 +180,7 @@ CHECKREQS_DISK_USR="4G"
 
 IUSE_FLAGS=(${FONTS[*],,})
 IUSE="+nerdfontssymbolsonly ${IUSE_FLAGS[*]}"
+RESTRICT="heavydata? ( bindist mirror )"
 REQUIRED_USE="|| ( nerdfontssymbolsonly ${IUSE_FLAGS[*]} )"
 
 FONT_S=${S}


### PR DESCRIPTION
因為 `Vic-Fieger-License` 僅涵蓋 HeavyData，且沒有授權再散布，所以依 `heavydata` USE flag 限制 `bindist` 與 `mirror`。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
