### PR TITLE
app-misc/bilihud: update pyqt6 USE

### DIFF
--- a/app-misc/bilihud/bilihud-9999.ebuild
+++ b/app-misc/bilihud/bilihud-9999.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 
 RDEPEND="${DEPEND}
 	dev-qt/qtwayland:6
-	dev-python/pyqt6[${PYTHON_USEDEP}]
+	dev-python/pyqt6[gui,multimedia,network,widgets,${PYTHON_USEDEP}]
 	dev-python/aiohttp[${PYTHON_USEDEP}]
 	dev-python/qasync[${PYTHON_USEDEP}]
 	app-arch/brotli[python,${PYTHON_USEDEP}]
@@ -42,6 +42,7 @@ BDEPEND="
 	dev-build/cmake
 	dev-build/ninja
 	virtual/pkgconfig
+	test? ( dev-python/pyqt6[testlib,${PYTHON_USEDEP}] )
 "
 
 python_configure_all() {


### PR DESCRIPTION
因为运行代码直接导入 `PyQt6.QtMultimedia`、`PyQt6.QtNetwork` 和 `PyQt6.QtWidgets`，所以 `RDEPEND` 中的 `dev-python/pyqt6` 需要启用 `gui`、`multimedia`、`network` 和 `widgets` USE flags。上游也在 [README](https://github.com/locez/bilihud/blob/main/README.md) 中说明桌面全屏礼物特效需要 `multimedia`。

因为测试导入 `PyQt6.QtTest.QTest`，所以 `test` USE 状态需要 `dev-python/pyqt6[testlib]`。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
