### PR TITLE
overlay.toml: track cachyos-sources by the linux-cachyos PKGBUILD

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2560,12 +2560,11 @@ github_account = "gouwazi"
 #["sys-fs/systemd-zpool-scrub"]
 
 ["sys-kernel/cachyos-sources"]
-source = "github"
-github = "CachyOS/linux"
-use_max_tag = true
-include_regex = "cachyos-[0-9.]+-[0-9]+"
-from_pattern = "cachyos-([0-9.]+)-[0-9]+"
-to_pattern = "\\1"
+source = "regex"
+url = "https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/PKGBUILD"
+regex = '_major=[\d.]+\n_minor=\d+'
+from_pattern = '_major=([\d.]+)\s+_minor=(\d+)'
+to_pattern = '\1.\2'
 github_account = ["blackteahamburger", "Zakkaus", "locez"]
 
 # Follows sys-kernel/gentoo-kernel and its dist-kernel release schedule rather


### PR DESCRIPTION
 因为 `CachyOS/linux` 先于内核包发布预打补丁的 tarball，其 tag 会在配套补丁 仍缺失或过期时触发 bump，所以改为读 `linux-cachyos/PKGBUILD` 里上游自己声明 的版本。 #12273

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
