### PR TITLE
media-plugins/kotonoha: add embedded-lyrics USE flag, require python[…

### DIFF
--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -6,6 +6,8 @@ EAPI=8
 DISTUTILS_USE_PEP517=scikit-build-core
 DISTUTILS_EXT=1
 PYTHON_COMPAT=( python3_{13..14} )
+# the lyrics cache is a sqlite3 database
+PYTHON_REQ_USE="sqlite"
 
 inherit desktop distutils-r1 git-r3 xdg
 
@@ -15,6 +17,7 @@ EGIT_REPO_URI="https://github.com/locez/kotonoha.git"
 
 LICENSE="ISC LGPL-2.1+ MIT"
 SLOT="0"
+IUSE="embedded-lyrics"
 
 DEPEND="
 	dev-libs/wayland
@@ -29,6 +32,7 @@ RDEPEND="
 	dev-python/qasync[${PYTHON_USEDEP}]
 	dev-qt/qtwayland:6
 	dev-qt/qtsvg:6
+	embedded-lyrics? ( media-libs/mutagen[${PYTHON_USEDEP}] )
 "
 BDEPEND="
 	dev-util/wayland-scanner

--- a/media-plugins/kotonoha/metadata.xml
+++ b/media-plugins/kotonoha/metadata.xml
@@ -5,6 +5,9 @@
 		<email>locez@locez.com</email>
 		<name>Locez</name>
 	</maintainer>
+	<use>
+		<flag name="embedded-lyrics">Read lyrics stored in local audio file tags via <pkg>media-libs/mutagen</pkg></flag>
+	</use>
 	<upstream>
 		<remote-id type="github">locez/kotonoha</remote-id>
 	</upstream>


### PR DESCRIPTION
上游 a5eab0f 新增讀取本地音檔 tag 內嵌歌詞,依賴 mutagen,對應可選旗標。
歌詞快取自 b9603f3 起用 sqlite3,補上 PYTHON_REQ_USE。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
