### PR TITLE
app-office/obsidian: update StartupWMClass

### DIFF
--- a/app-office/obsidian/obsidian-1.13.7-r1.ebuild
+++ b/app-office/obsidian/obsidian-1.13.7-r1.ebuild
@@ -110,8 +110,9 @@ src_install() {
 		exec+=" --ozone-platform-hint=auto --enable-wayland-ime"
 	fi
 
-	# The window reports WM_CLASS "md.obsidian", "md.Obsidian"; a StartupWMClass
-	# that does not match leaves the running window without this entry's icon.
+	# The window reports WM_CLASS "md.obsidian.obsidian", "md.obsidian.Obsidian";
+	# a StartupWMClass that does not match leaves the running window without this
+	# entry's icon.
 	cat > "${T}/${PN}.desktop" <<-EOF || die
 		[Desktop Entry]
 		Type=Application
@@ -120,7 +121,7 @@ src_install() {
 		Exec=${exec} %u
 		Icon=${PN}
 		Terminal=false
-		StartupWMClass=md.Obsidian
+		StartupWMClass=md.obsidian.Obsidian
 		Categories=Office;
 		MimeType=x-scheme-handler/obsidian;
 	EOF


### PR DESCRIPTION
因为上游把窗口的 `WM_CLASS` 从 `md.Obsidian` 改成 `md.obsidian.Obsidian`，所以 `StartupWMClass` 也要跟着改，否则运行中的窗口匹配不到这个 desktop 条目，任务栏只显示默认图标。

Closes #12303
