### PR TITLE
overlay.toml: stop autobumping app-admin/1password

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -54,7 +54,6 @@ mirror = "https://downloads.1password.com/linux/debian/amd64"
 suite = "stable"
 # strip_release = true
 github_account = ["yangmame", "peeweep", "gouwazi"]
-autobump = true
 
 ["app-admin/chezmoi"]
 source = "github"


### PR DESCRIPTION
1password 的 `src_install` 有 `fowners root:onepassword`,autobump 只跑 install 不拉依賴,`acct-group/onepassword` 不在,整包必炸。改回人工 bump。

- 證據:#12602 的 autobump 跑掛在 `chown: invalid group: 'root:onepassword'`
- 本機帶依賴建置 8.12.34 正常(#12602 對應的 PR 另開)