### PR TITLE
overlay.toml: track rstudio-desktop-bin by its update endpoint

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2482,12 +2482,11 @@ use_latest_release = true
 prefix = "v"
 github_account = "xz-dev"
 
-# https://www.rstudio.org/links/check_for_update?version=1.0.0&os=linux
 ["sci-mathematics/rstudio-desktop-bin"]
-source = "github"
-github = "rstudio/rstudio"
-use_latest_tag = true
-from_pattern = 'v(.*)\+(.*)'
+source = "regex"
+url = "https://www.rstudio.org/links/check_for_update?version=1.0.0&os=linux"
+regex = 'update-version=([\d.]+%2B\d+)'
+from_pattern = '(.*)%2B(\d+)'
 to_pattern = '\1_p\2'
 github_account = ["zakkaus", "peeweep"]
 autobump = true


### PR DESCRIPTION
`use_latest_tag` 追 `rstudio/rstudio` 的 git tag,但 tag 在打包流程一開始就推,deb 要晚幾天才上 `download1.rstudio.org`,所以 nvchecker 會提早開 issue、autobump 抓檔 404。

改追上游自己的更新檢查 endpoint(原本寫在那行註解裡),它回的是實際發布的版本。

- 現在 tag 是 `v2026.08.2+200`,但 `rstudio-2026.08.2-200-amd64.deb` 在 jammy/noble 兩個路徑都 404,舊版 `2026.08.1-195` 回 200
- 本機跑 nvchecker 驗過:`updated to 2026.08.1_p195`,與樹上版本一致

Closes #12594

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.