### PR TITLE
dev-util/herdr-bin: update upstream repository

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2292,7 +2292,7 @@ github_account = ["yangmame", "peeweep"]
 
 ["net-proxy/hysteria"]
 source = "github"
-github = "apernet/hysteria"
+github = "HyNetworks/hysteria"
 use_latest_release = true
 prefix = "app/v"
 github_account = ["oatiz", "gouwazi"]

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1206,7 +1206,7 @@ github_account = "zakkaus"
 
 ["dev-util/herdr-bin"]
 source = "github"
-github = "ogulcancelik/herdr"
+github = "herdrdev/herdr"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"

--- a/dev-util/herdr-bin/herdr-bin-0.8.2.ebuild
+++ b/dev-util/herdr-bin/herdr-bin-0.8.2.ebuild
@@ -4,10 +4,10 @@
 EAPI=8
 
 MY_PN="${PN%-bin}"
-URI_PREFIX="https://github.com/ogulcancelik/${MY_PN}/releases/download/v${PV}"
+URI_PREFIX="https://github.com/herdrdev/${MY_PN}/releases/download/v${PV}"
 
 DESCRIPTION="Terminal workspace manager for AI coding agents"
-HOMEPAGE="https://herdr.dev https://github.com/ogulcancelik/herdr"
+HOMEPAGE="https://herdr.dev https://github.com/herdrdev/herdr"
 SRC_URI="
 	amd64? ( ${URI_PREFIX}/${MY_PN}-linux-x86_64 -> ${P}-amd64 )
 	arm64? ( ${URI_PREFIX}/${MY_PN}-linux-aarch64 -> ${P}-arm64 )

--- a/dev-util/herdr-bin/metadata.xml
+++ b/dev-util/herdr-bin/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Xianggang Wang</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">ogulcancelik/herdr</remote-id>
+		<remote-id type="github">herdrdev/herdr</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-proxy/hysteria/hysteria-2.12.2.ebuild
+++ b/net-proxy/hysteria/hysteria-2.12.2.ebuild
@@ -7,10 +7,10 @@ inherit go-module systemd
 COMMIT_ID="14e9fff1d972ab0187ac7fcf75b9514dc8664065"
 
 DESCRIPTION="A powerful, lightning fast and censorship resistant proxy"
-HOMEPAGE="https://github.com/apernet/hysteria"
+HOMEPAGE="https://github.com/HyNetworks/hysteria"
 
 SRC_URI="
-	https://github.com/apernet/hysteria/archive/refs/tags/app/v${PV}.tar.gz -> ${P}.tar.gz
+	https://github.com/HyNetworks/hysteria/archive/refs/tags/app/v${PV}.tar.gz -> ${P}.tar.gz
 	https://github.com/gentoo-zh-drafts/hysteria/releases/download/app/v${PV}/hysteria-app-v${PV}-vendor.tar.xz
 		-> ${P}-vendor.tar.xz
 "

--- a/net-proxy/hysteria/metadata.xml
+++ b/net-proxy/hysteria/metadata.xml
@@ -7,6 +7,6 @@ pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 		<email>iamoatiz@gmail.com</email>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">apernet/hysteria</remote-id>
+		<remote-id type="github">HyNetworks/hysteria</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
两个包的上游仓库都改名了，`pkgcheck --net` 报 `RedirectedUrl`。

- `dev-util/herdr-bin`：`ogulcancelik/herdr` → `herdrdev/herdr`
- `net-proxy/hysteria`：`apernet/hysteria` → `HyNetworks/hysteria`

两处的 distfile 从新地址取回的字节与 Manifest 一致，校验和不变。hysteria `src_compile` 里的 `github.com/apernet/hysteria/app/v2/cmd` 和 `github.com/apernet/quic-go` 是 Go 模块路径不是仓库地址，上游 `go.mod` 仍然是 apernet，未改动。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.