### PR TITLE
x11-themes/nordzy-icon: update upstream repository

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2815,7 +2815,7 @@ github_account = "hertz-hwang"
 
 ["x11-themes/nordzy-icon"]
 source = "github"
-github = "alvatip/Nordzy-icon"
+github = "MolassesLover/Nordzy-icon"
 use_latest_release = true
 github_account = ["hertz-hwang", "gouwazi"]
 

--- a/x11-themes/nordzy-icon/metadata.xml
+++ b/x11-themes/nordzy-icon/metadata.xml
@@ -6,6 +6,6 @@
                 <name>Jaus Hwang</name>    
         </maintainer>    
         <upstream>    
-                <remote-id type="github">alvatip/Nordzy-icon</remote-id>    
+                <remote-id type="github">MolassesLover/Nordzy-icon</remote-id>    
         </upstream>    
 </pkgmetadata>

--- a/x11-themes/nordzy-icon/nordzy-icon-1.8.7.ebuild
+++ b/x11-themes/nordzy-icon/nordzy-icon-1.8.7.ebuild
@@ -6,8 +6,8 @@ EAPI=8
 inherit xdg
 
 DESCRIPTION="A free and open source icon theme for Linux desktops"
-HOMEPAGE="https://github.com/alvatip/Nordzy-icon"
-SRC_URI="https://github.com/alvatip/Nordzy-icon/releases/download/${PV}/Nordzy.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/MolassesLover/Nordzy-icon"
+SRC_URI="https://github.com/MolassesLover/Nordzy-icon/releases/download/${PV}/Nordzy.tar.gz -> ${P}.tar.gz"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
因为上游把仓库迁到 MolassesLover/Nordzy-icon，所以 `SRC_URI`、`HOMEPAGE`、`metadata.xml` 的 remote-id 和 `.github/workflows/overlay.toml` 的追踪地址一并改到新地址。从新地址取回的字节与 Manifest 一致，校验和不变。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.