### PR TITLE
net-dns/ddns-go: add OpenRC service script

### DIFF
--- a/net-dns/ddns-go/ddns-go-6.17.6.ebuild
+++ b/net-dns/ddns-go/ddns-go-6.17.6.ebuild
@@ -33,6 +33,9 @@ src_compile() {
 
 src_install() {
 	dobin "${PN}"
+	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
+	newconfd "${FILESDIR}/${PN}.confd" "${PN}"
+
 	systemd_dounit "${FILESDIR}/${PN}.service"
 	systemd_newunit "${FILESDIR}/${PN}_at.service" "${PN}@.service"
 	systemd_dounit "${FILESDIR}/${PN}-web.service"

--- a/net-dns/ddns-go/files/ddns-go.confd
+++ b/net-dns/ddns-go/files/ddns-go.confd
@@ -1,0 +1,12 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Configuration file. A service named ddns-go.<name> reads
+# /etc/ddns-go/<name>.yaml instead.
+#DDNS_GO_CONFIG="/etc/ddns-go/config.yaml"
+
+# Serve the web interface on :9876, as ddns-go-web.service does.
+#DDNS_GO_WEB="yes"
+
+# Extra command line arguments, for example -l :9877 -f 600.
+#DDNS_GO_ARGS=""

--- a/net-dns/ddns-go/files/ddns-go.initd
+++ b/net-dns/ddns-go/files/ddns-go.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Simple and easy to use DDNS client"
+
+instance="${RC_SVCNAME#*.}"
+[ "${instance}" = "${RC_SVCNAME}" ] && instance="config"
+DDNS_GO_CONFIG="${DDNS_GO_CONFIG:-/etc/ddns-go/${instance}.yaml}"
+
+command="/usr/bin/ddns-go"
+command_args="-c ${DDNS_GO_CONFIG} ${DDNS_GO_ARGS}"
+yesno "${DDNS_GO_WEB:-no}" || command_args="${command_args} -noweb"
+command_background="true"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+	need net
+	after dns
+}


### PR DESCRIPTION
因为它只安装了 systemd unit，OpenRC 用户装完没有服务可用，所以补一个 init 脚本和 conf.d。用 `RC_SVCNAME` 的后缀选配置文件，对应 `ddns-go@.service`；`DDNS_GO_WEB` 打开时不加 `-noweb`，对应 `ddns-go-web.service`。

cc @Puqns67

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.