### PR TITLE
net-misc/ntpd-rs: add OpenRC service scripts

### DIFF
--- a/net-misc/ntpd-rs/files/ntpd-rs-metrics.initd
+++ b/net-misc/ntpd-rs/files/ntpd-rs-metrics.initd
@@ -1,0 +1,21 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Network Time Service (ntpd-rs) metrics exporter"
+
+command="/usr/bin/ntp-metrics-exporter"
+command_args="${NTPD_RS_METRICS_ARGS}"
+command_background="true"
+command_user="ntpd-rs-observe:ntpd-rs-observe"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+export RUST_LOG="${RUST_LOG:-info}"
+
+depend() {
+	need ntpd-rs
+}
+
+start_pre() {
+	checkpath -d -m 0755 -o ntpd-rs-observe:ntpd-rs-observe /run/ntpd-rs-observe
+}

--- a/net-misc/ntpd-rs/files/ntpd-rs.initd
+++ b/net-misc/ntpd-rs/files/ntpd-rs.initd
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Network Time Service (ntpd-rs)"
+
+command="/usr/bin/ntp-daemon"
+command_args="${NTPD_RS_ARGS}"
+command_background="true"
+command_user="ntpd-rs:ntpd-rs"
+capabilities="^cap_sys_time,^cap_net_bind_service"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+export RUST_LOG="${RUST_LOG:-info}"
+
+depend() {
+	need net
+}
+
+start_pre() {
+	checkpath -d -m 0755 -o ntpd-rs:ntpd-rs /run/ntpd-rs
+}

--- a/net-misc/ntpd-rs/ntpd-rs-1.9.0.ebuild
+++ b/net-misc/ntpd-rs/ntpd-rs-1.9.0.ebuild
@@ -49,6 +49,9 @@ src_install(){
 	insinto /etc/ntpd-rs
 	doins ../ntp.toml
 
+	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
+	use metrics && newinitd "${FILESDIR}/${PN}-metrics.initd" "${PN}-metrics"
+
 	systemd_dounit ../docs/examples/conf/ntpd-rs-metrics.service
 	systemd_dounit ../docs/examples/conf/ntpd-rs.service
 }


### PR DESCRIPTION
因为它只安装了 systemd unit，OpenRC 用户装完没有服务可用，所以补两个 init 脚本。`capabilities` 对应 unit 的 `AmbientCapabilities`，`checkpath` 对应 `RuntimeDirectory`。

因为 `acct-user/ntpd-rs-observe` 只在 `metrics` 下安装，所以 metrics 的脚本也跟着这个 USE 走。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.