### PR TITLE
net-proxy/clash-rs: add OpenRC service script

### DIFF
--- a/net-proxy/clash-rs/clash-rs-0.10.8.ebuild
+++ b/net-proxy/clash-rs/clash-rs-0.10.8.ebuild
@@ -119,5 +119,6 @@ src_install() {
 	dobin "$(cargo_target_dir)"/clash-rs
 	insinto "/etc/clash-rs"
 	doins "${FILESDIR}/config.example.yaml"
+	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 	systemd_dounit "${FILESDIR}/clash-rs.service"
 }

--- a/net-proxy/clash-rs/files/clash-rs.initd
+++ b/net-proxy/clash-rs/files/clash-rs.initd
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Another Clash kernel, written in Rust"
+
+CLASH_RS_CONF_DIR="${CLASH_RS_CONF_DIR:-/etc/clash-rs}"
+
+command="/usr/bin/clash-rs"
+command_args="-d ${CLASH_RS_CONF_DIR} ${CLASH_RS_ARGS}"
+command_background="true"
+capabilities="^cap_net_admin"
+pidfile="/run/${RC_SVCNAME}.pid"
+required_files="${CLASH_RS_CONF_DIR}/config.yaml"
+
+depend() {
+	need net
+	after local
+}


### PR DESCRIPTION
因为它只安装了 systemd unit，OpenRC 用户装完没有服务可用，所以补一个 init 脚本，写法跟同类的 net-proxy/mihomo 一致。`required_files` 检查 `config.yaml`，因为 ebuild 只装 `config.example.yaml`，缺配置时 clash-rs 直接退出。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.