### PR TITLE
net-vpn/rathole: add OpenRC service scripts

### DIFF
--- a/net-vpn/rathole/files/ratholec.initd
+++ b/net-vpn/rathole/files/ratholec.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Rathole client"
+
+instance="${RC_SVCNAME#*.}"
+[ "${instance}" = "${RC_SVCNAME}" ] && instance="rathole"
+RATHOLE_CONFIG="${RATHOLE_CONFIG:-/etc/rathole/${instance}.toml}"
+
+command="/usr/bin/rathole"
+command_args="-c ${RATHOLE_CONFIG}"
+command_background="true"
+rc_ulimit="-n 1048576"
+pidfile="/run/${RC_SVCNAME}.pid"
+required_files="${RATHOLE_CONFIG}"
+
+depend() {
+	need net
+}

--- a/net-vpn/rathole/files/ratholes.initd
+++ b/net-vpn/rathole/files/ratholes.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Rathole server"
+
+instance="${RC_SVCNAME#*.}"
+[ "${instance}" = "${RC_SVCNAME}" ] && instance="rathole"
+RATHOLE_CONFIG="${RATHOLE_CONFIG:-/etc/rathole/${instance}.toml}"
+
+command="/usr/bin/rathole"
+command_args="-s ${RATHOLE_CONFIG}"
+command_background="true"
+rc_ulimit="-n 1048576"
+pidfile="/run/${RC_SVCNAME}.pid"
+required_files="${RATHOLE_CONFIG}"
+
+depend() {
+	need net
+}

--- a/net-vpn/rathole/rathole-0.5.0.ebuild
+++ b/net-vpn/rathole/rathole-0.5.0.ebuild
@@ -31,6 +31,9 @@ PATCHES=("${FILESDIR}/${P}-fix-rust-1.80.patch")
 src_install(){
 	keepdir /etc/rathole
 	dobin $(cargo_target_dir)/rathole
+	newinitd "${FILESDIR}/ratholes.initd" ratholes
+	newinitd "${FILESDIR}/ratholec.initd" ratholec
+
 	systemd_dounit examples/systemd/ratholes@.service
 	systemd_dounit examples/systemd/ratholes.service
 	systemd_dounit examples/systemd/ratholec@.service


### PR DESCRIPTION
因为它只安装了 systemd unit，OpenRC 用户装完没有服务可用，所以补 `ratholes` 和 `ratholec` 两个 init 脚本，分别对应服务端和客户端。用 `RC_SVCNAME` 的后缀选配置文件，对应 `ratholes@.service` 和 `ratholec@.service`；`rc_ulimit` 对应 unit 的 `LimitNOFILE`。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.