### PR TITLE
www-servers/s-ui-bin: add OpenRC service script, keep the database in /var/lib

### DIFF
--- a/www-servers/s-ui-bin/files/s-ui.initd
+++ b/www-servers/s-ui-bin/files/s-ui.initd
@@ -1,0 +1,15 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="An advanced web panel built for sing-box"
+
+supervisor=supervise-daemon
+command="/usr/bin/sui"
+directory="/var/lib/s-ui"
+
+export SUI_DB_FOLDER="${SUI_DB_FOLDER:-/var/lib/s-ui}"
+
+depend() {
+	need net
+}

--- a/www-servers/s-ui-bin/s-ui-bin-1.5.5.ebuild
+++ b/www-servers/s-ui-bin/s-ui-bin-1.5.5.ebuild
@@ -22,12 +22,14 @@ RESTRICT="strip"
 src_prepare() {
 	sed -i 's|ExecStart=.*|ExecStart=/usr/bin/sui|' "${S}/s-ui/s-ui.service" || die
 	sed -i 's|WorkingDirectory=.*|WorkingDirectory=/var/lib/s-ui|' "${S}/s-ui/s-ui.service" || die
+	sed -i '/^WorkingDirectory=/aEnvironment=SUI_DB_FOLDER=/var/lib/s-ui' "${S}/s-ui/s-ui.service" || die
 
 	default
 }
 
 src_install() {
 	dobin "${S}/s-ui/sui"
+	newinitd "${FILESDIR}/s-ui.initd" s-ui
 	systemd_dounit "${S}/s-ui/s-ui.service"
 	keepdir /var/lib/s-ui
 }


### PR DESCRIPTION
因为它只安装了 systemd unit，OpenRC 用户装完没有服务可用，所以补一个 init 脚本。

因为 s-ui 按可执行文件所在目录推算数据库路径，装到 /usr/bin 之后会往 `/usr/bin/db/` 写 sqlite 文件，`WorkingDirectory` 改不了它，所以 unit 和 init 脚本都设 `SUI_DB_FOLDER=/var/lib/s-ui`。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.