### PR TITLE
sys-kernel/cachyos-sources: select the CJK font when USE=cjk

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-7.2.1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-7.2.1.ebuild
@@ -224,6 +224,11 @@ src_prepare() {
 
 	scripts/config -e CACHY || die
 
+	# FONT_CJK_16x16 is default y, but the 32x32 data patch USE=cjk32
+	# fetches has no effect until the option it fills is selected.
+	# --keep-case: scripts/config would upper-case the symbol name.
+	use cjk32 && { scripts/config --keep-case -e FONT_CJK_32x32 || die; }
+
 	if use bore; then
 		scripts/config -e SCHED_BORE || die
 	elif use rt; then


### PR DESCRIPTION
The cjktty patch renders nothing until the font is enabled, and this package ships a populated .config the user builds as-is.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
