### PR TITLE
www-servers/s-ui-bin: do not supervise the service

### DIFF
--- a/www-servers/s-ui-bin/files/s-ui.initd
+++ b/www-servers/s-ui-bin/files/s-ui.initd
@@ -4,9 +4,10 @@
 
 description="An advanced web panel built for sing-box"
 
-supervisor=supervise-daemon
 command="/usr/bin/sui"
+command_background="true"
 directory="/var/lib/s-ui"
+pidfile="/run/${RC_SVCNAME}.pid"
 
 export SUI_DB_FOLDER="${SUI_DB_FOLDER:-/var/lib/s-ui}"
 


### PR DESCRIPTION
因为 unit 只写了 `Restart=on-failure` 而 `supervise-daemon` 会无限重启，与 OpenRC 里其他包的做法也不一致，所以改回 `command_background` 加 `pidfile`，跟树里多数 init 脚本一样不做监管。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.