### PR TITLE
sys-kernel: slot the sources packages by PV, not PVR

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-7.2.2-r1.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-7.2.2-r1.ebuild
@@ -90,6 +90,7 @@ SRC_URI+="
 "
 
 LICENSE+=" kernel-builtin-zfs? ( BSD-2 CDDL GPL-3 MIT )"
+SLOT="${PV}"
 KEYWORDS="~amd64"
 IUSE+="
 	+bore bmq muqss rt rt-bore eevdf

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.104.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.104.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.105.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.105.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.106.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.106.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.107.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.12.107.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.45.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.45.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.46.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.46.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.47.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.47.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.48.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-6.18.48.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.10.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.10.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.11.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.11.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.12.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.12.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.8-r1.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.8-r1.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.9.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.1.9.ebuild
@@ -21,6 +21,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.2.0.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.2.0.ebuild
@@ -22,6 +22,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.2.1.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.2.1.ebuild
@@ -22,6 +22,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.2.2.ebuild
+++ b/sys-kernel/gentoo-cjk-sources/gentoo-cjk-sources-7.2.2.ebuild
@@ -22,6 +22,7 @@ DESCRIPTION="Gentoo kernel sources with the cjktty patch for CJK text on the con
 HOMEPAGE="https://github.com/gentoo-zh/cjktty-patches"
 SRC_URI+=" ${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI}"
 S="${WORKDIR}/linux-${KV_FULL}"
+SLOT="${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE+=" +cjk experimental"
 

--- a/sys-kernel/liquorix-sources/liquorix-sources-7.1.12.ebuild
+++ b/sys-kernel/liquorix-sources/liquorix-sources-7.1.12.ebuild
@@ -43,6 +43,7 @@ SRC_URI+="
 
 S="${WORKDIR}/linux-${PV}-liquorix"
 
+SLOT="${PV}"
 KEYWORDS="~amd64"
 # To use CJKTTY, Please enable this USE
 IUSE+=" +cjk"

--- a/sys-kernel/xanmod-sources/xanmod-sources-7.1.11.ebuild
+++ b/sys-kernel/xanmod-sources/xanmod-sources-7.1.11.ebuild
@@ -30,6 +30,7 @@ SRC_URI+="
 "
 S="${WORKDIR}/linux-${OKV}${XANMOD_VERSION}"
 
+SLOT="${PV}"
 KEYWORDS="~amd64"
 IUSE+=" cjk"
 


### PR DESCRIPTION
kernel-2.eclass sets SLOT to PVR, so cachyos-sources-7.2.2-r1 installs into slot 7.2.2-r1 beside an installed 7.2.2 rather than replacing it. Every revbump forks a slot and leaves the previous kernel merged.

Verified with `portageq metadata / ebuild sys-kernel/cachyos-sources-7.2.2-r1 SLOT`: 7.2.2-r1 before, 7.2.2 after. Versions without a revision are unchanged.

Anyone already carrying a forked slot needs `emerge -C` on the old one; portage will not remove it.