### PR TITLE
app-misc/bilihud: add svg USE for PyQt6

### DIFF
--- a/app-misc/bilihud/bilihud-9999.ebuild
+++ b/app-misc/bilihud/bilihud-9999.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 
 RDEPEND="${DEPEND}
 	dev-qt/qtwayland:6
-	dev-python/pyqt6[gui,multimedia,network,widgets,${PYTHON_USEDEP}]
+	dev-python/pyqt6[gui,multimedia,network,svg,widgets,${PYTHON_USEDEP}]
 	dev-python/aiohttp[${PYTHON_USEDEP}]
 	dev-python/qasync[${PYTHON_USEDEP}]
 	app-arch/brotli[python,${PYTHON_USEDEP}]


### PR DESCRIPTION
因为 bilihud 使用 PyQt6 的 SVG 模块，所以 `RDEPEND` 中的 `dev-python/pyqt6` 需要启用 `svg` USE flag，避免运行时导入 SVG 模块失败。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
