### PR TITLE
sys-kernel/cachyos-sources: add 7.2.2-r3, drop 7.2.2-r2

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-7.2.2-r3.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-7.2.2-r3.ebuild
@@ -6,8 +6,6 @@ EAPI="8"
 ETYPE="sources"
 EXTRAVERSION="-cachyos"
 K_NOSETEXTRAVERSION="1"
-# Use the pre-patched CachyOS release tarball.
-K_PREPATCHED="1"
 
 # Pin patch and config inputs so Manifest checks cover exact upstream bytes.
 CACHYOS_PATCHES_COMMIT="a40b85abdcb9f4ba653e2e1ea89d3d1f0cf563ba"
@@ -188,8 +186,6 @@ src_unpack() {
 src_prepare() {
 	local patches_prefix="${DISTDIR}/${CACHYOS_PATCH_PREFIX}"
 	local configs_prefix="${DISTDIR}/${CACHYOS_CONFIG_PREFIX}"
-	local cachyos_revision="${PR#r}"
-	local cachyos_localversion="-cachyos"
 	local march_flag march=""
 	local -a march_flags=(
 		mgeneric mgeneric-v1 mgeneric-v2 mgeneric-v3 mgeneric-v4 mnative mzen4
@@ -233,11 +229,9 @@ src_prepare() {
 	# CachyOS ships this generated BPF object; remove it so sources remain rebuildable.
 	rm -f tools/testing/selftests/tc-testing/action-ebpf || die
 
-	# Follow upstream localversion naming and append Gentoo's revision when present.
-	if [[ ${cachyos_revision} != 0 ]]; then
-		cachyos_localversion+="${cachyos_revision}"
-	fi
-	echo "${cachyos_localversion}" > localversion.20-pkgname || die
+	# Take the suffix from KV_FULL so the source directory, the slot and
+	# kernelrelease cannot drift apart across revisions.
+	echo "${KV_FULL#${PV}}" > localversion.20-pkgname || die
 
 	if use server; then
 		scripts/config -d CACHY || die


### PR DESCRIPTION
K_PREPATCHED spells the revision as a bare digit, so the tree read linux-7.2.2-cachyos2 while r0 read cachyos0. Deriving the suffix from KV_FULL keeps directory, slot and kernelrelease one string.
<img width="1343" height="183" alt="圖片" src="https://github.com/user-attachments/assets/ed1b19eb-7b89-4945-ae11-145c3290b582" />

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
