### PR TITLE
app-editors/cursor: rename BUILD_ID to MY_COMMIT

### DIFF
--- a/app-editors/cursor/cursor-3.18.9.ebuild
+++ b/app-editors/cursor/cursor-3.18.9.ebuild
@@ -9,17 +9,17 @@ CHROMIUM_LANGS="af am ar bg bn ca cs da de el en-GB es es-419 et fa fi fil fr gu
 
 inherit chromium-2 desktop optfeature pax-utils shell-completion unpacker xdg
 
-BUILD_ID="2ba48ff3f7514cc4643c52ca9f7b3173d9b66137"
+MY_COMMIT="2ba48ff3f7514cc4643c52ca9f7b3173d9b66137"
 
 DESCRIPTION="Cursor App - AI-first coding environment"
 HOMEPAGE="https://cursor.com/"
 SRC_URI="
 	amd64? (
-		https://downloads.cursor.com/production/${BUILD_ID}/linux/x64/deb/amd64/deb/cursor_${PV}_amd64.deb
+		https://downloads.cursor.com/production/${MY_COMMIT}/linux/x64/deb/amd64/deb/cursor_${PV}_amd64.deb
 			-> ${P}-amd64.deb
 	)
 	arm64? (
-		https://downloads.cursor.com/production/${BUILD_ID}/linux/arm64/deb/arm64/deb/cursor_${PV}_arm64.deb
+		https://downloads.cursor.com/production/${MY_COMMIT}/linux/arm64/deb/arm64/deb/cursor_${PV}_arm64.deb
 			-> ${P}-arm64.deb
 	)
 "

--- a/media-video/piliplus-bin/piliplus-bin-2.1.2.3.ebuild
+++ b/media-video/piliplus-bin/piliplus-bin-2.1.2.3.ebuild
@@ -7,8 +7,8 @@ inherit xdg desktop wrapper
 
 DESCRIPTION="BiliBili third-party client developed using Flutter"
 HOMEPAGE="https://github.com/bggRGjQaUbCoE/PiliPlus"
-PVER="2.1.2+5281"
-SRC_URI="https://github.com/bggRGjQaUbCoE/PiliPlus/releases/download/${PV}/PiliPlus_linux_${PVER}_amd64.tar.gz"
+MY_PV="2.1.2+5281"
+SRC_URI="https://github.com/bggRGjQaUbCoE/PiliPlus/releases/download/${PV}/PiliPlus_linux_${MY_PV}_amd64.tar.gz"
 S="${WORKDIR}"
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-proxy/hysteria/hysteria-2.12.2.ebuild
+++ b/net-proxy/hysteria/hysteria-2.12.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 inherit go-module systemd
 
-COMMIT_ID="14e9fff1d972ab0187ac7fcf75b9514dc8664065"
+MY_COMMIT="14e9fff1d972ab0187ac7fcf75b9514dc8664065"
 
 DESCRIPTION="A powerful, lightning fast and censorship resistant proxy"
 HOMEPAGE="https://github.com/HyNetworks/hysteria"
@@ -45,7 +45,7 @@ src_compile() {
 		-X ${APP_SRC_CMD_PKG}.appPlatform=linux \
 		-X ${APP_SRC_CMD_PKG}.appArch=$(go env GOARCH) \
 		-X '${APP_SRC_CMD_PKG}.appToolchain=$(go env GOVERSION)' \
-		-X ${APP_SRC_CMD_PKG}.appCommit=${COMMIT_ID} \
+		-X ${APP_SRC_CMD_PKG}.appCommit=${MY_COMMIT} \
 		-X ${APP_SRC_CMD_PKG}.libVersion=${APP_LIB_VERSION} \
 		" \
 		-o "${PN}" "./app"


### PR DESCRIPTION
三个包各自发明了一个变量名装同一类东西，改用主树已有的写法。

`app-editors/cursor` 的 `BUILD_ID` 和 `net-proxy/hysteria` 的 `COMMIT_ID` 装的都是上游 commit sha，改成 `MY_COMMIT`；gentoo.git 里 `MY_COMMIT` 有 84 个 ebuild 在用，`BUILD_ID` 一个也没有。`media-video/piliplus-bin` 的 `PVER` 装的是上游自己的版本字串（`PV` 加建置号），改成 devmanual 给这种情况的 `MY_PV`，主树 1016 个 ebuild 在用。

`dev-util/grok-build-bin` 已经是 `MY_COMMIT`，不动。

只改变量名和它的引用，值和安装内容都不变，所以不 revbump。hysteria 那个值仍然经 `-X appCommit` 编进二进制。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
