### PR TITLE
scripts/autobump-args: one parser for a package's engine flags

### DIFF
--- a/.github/workflows/autobump-recommend.yml
+++ b/.github/workflows/autobump-recommend.yml
@@ -140,7 +140,8 @@ jobs:
             ver=$(sed -nE 's/.* can be bump to ([A-Za-z0-9._+-]+)$/\1/p' <<<"$title")
             [ -n "$pkg" ] && [ -n "$ver" ] || continue
             echo "==== trial #$n  $pkg -> $ver ===="
-            ruby autobump-rb/bin/autobump "$n" --install; ec=$?   # build+install+pkgcheck, no --pr, no opt-in
+            args=(); a=$(python3 scripts/autobump-args.py "$pkg") && [ -n "$a" ] && mapfile -t args <<<"$a"
+            ruby autobump-rb/bin/autobump "$n" --install "${args[@]}"; ec=$?   # build+install+pkgcheck, no --pr, no opt-in
             [ "$ec" = 0 ] && built="${built}- #${n}  ${pkg} -> ${ver}"$'\n'
           done
           [ -n "$built" ] || built='(no not-opted-in candidate built OK this run)'

--- a/.github/workflows/autobump-trial.yml
+++ b/.github/workflows/autobump-trial.yml
@@ -151,7 +151,9 @@ jobs:
           fi
           echo "==== #$n  $pkg -> $ver ===="
           trial_comment "$n" "**autobump-trial** build-testing \`$pkg\` → \`$ver\` (not opted in)… · [run]($RUN_URL)"
-          ruby autobump-rb/bin/autobump "$n" --install; ec=$?   # build+install+pkgcheck, no --pr, no opt-in
+          # the package's own rewrite/retention flags, so a trial runs what a real sweep would
+          args=(); a=$(python3 scripts/autobump-args.py "$pkg") && [ -n "$a" ] && mapfile -t args <<<"$a"
+          ruby autobump-rb/bin/autobump "$n" --install "${args[@]}"; ec=$?   # build+install+pkgcheck, no --pr, no opt-in
           case "$ec" in
             0)   res='PASS — mechanical, built + installed + pkgcheck clean' ;;
             3)   res='FAIL — escalate / build-fail (major jump, deps, patch, vendor, or emerge/QA/pkgcheck failure)' ;;

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -169,6 +169,7 @@ source = "regex"
 url = "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/releases"
 regex = '"version":"([\d.]+)"'
 github_account = "zakkaus"
+# autobump off: ICON_COMMIT does not track the package version
 
 ["app-editors/antigravity-ide"]
 source = "regex"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -150,8 +150,7 @@ source = "github"
 github = "outloudvi/mw2fcitx"
 use_latest_release = true
 github_account = "blackteahamburger"
-autobump = true
-keep_old = 3
+autobump = 3
 
 ["app-dicts/fcitx-pinyin-sougou-dict"]
 source = "github"
@@ -549,8 +548,7 @@ github = "mikefarah/yq"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
-autobump = true
-keep_old = 2
+autobump = 2
 
 ["app-misc/gpick"]
 source = "github"
@@ -1398,8 +1396,7 @@ github = "sourcegit-scm/sourcegit"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
-autobump = true
-keep_old = 3
+autobump = 3
 
 ["games-action/vintagestory"]
 source = "regex"
@@ -1542,8 +1539,7 @@ github = "lxgw/LxgwNeoXiHei"
 use_latest_release = true
 prefix = "v"
 github_account = "Linerre"
-autobump = true
-keep_old = 2
+autobump = 2
 
 ["media-fonts/lxgw-neo-zhisong"]
 source = "github"
@@ -1609,8 +1605,7 @@ github = "be5invis/sarasa-gothic"
 use_latest_release = true
 prefix = "v"
 github_account = "Linerre"
-autobump = true
-keep_old = 2
+autobump = 2
 
 ["media-fonts/sarasa-term-sc-nerd"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -175,6 +175,8 @@ source = "regex"
 url = "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/releases"
 regex = '"version":"([\d.]+)"'
 github_account = "zakkaus"
+autobump = true
+autobump_my_build_regex = '"version":"${PV}","execution_id":"([0-9]+)"'
 
 ["app-editors/appflowy-bin"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -188,6 +188,8 @@ source = "regex"
 url = "https://cursor.com/api/download?platform=linux-x64&releaseTrack=latest"
 regex = '"version":"([\d.]+)"'
 github_account = "zakkaus"
+autobump = true
+autobump_my_commit_regex = '"commitSha":"([0-9a-f]{40})"'
 
 ["app-editors/edit"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1873,6 +1873,9 @@ source = "aur"
 aur = "piliplus-bin"
 strip_release = true
 github_account = ["xysgh", "gouwazi"]
+autobump = true
+autobump_my_pv_url = "https://api.github.com/repos/bggRGjQaUbCoE/PiliPlus/releases/tags/${PV}"
+autobump_my_pv_regex = 'PiliPlus_linux_([^"_]+)_amd64\.tar\.gz'
 
 # TODO: upstream removed linux support
 #["media-video/tenvideo"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ A bump replaces the version it supersedes—`add NEW, drop OLD`. Retention is th
 - Otherwise drop. A package with no cross-version state, no reverse dependencies, and nothing worth downgrading to keeps exactly one version. Being prebuilt is not a reason to keep the old one.
 - Follow the package's own history where it shows an explicit pattern; otherwise apply the rules above and state the choice. Never keep a version merely because the previous commit did.
 - Stop for direction when an old version loses its immutable source bytes, or when a replacement in place is unexplained.
-- `keep_old = N` in `.github/workflows/overlay.toml` applies the same policy to autobump: set it only for a package meeting a reason above, and remove it when the reason lapses.
+- `autobump = N` in `.github/workflows/overlay.toml` applies the same policy to autobump: set a number only for a package meeting a reason above, and return it to `true` when the reason lapses.
 
 ## Dependencies and Revisions
 

--- a/scripts/autobump-args.py
+++ b/scripts/autobump-args.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Print a package's autobump engine flags, one per line.
+
+Shared by autobump-sweep, autobump-probe, autobump-trial.yml and autobump-recommend.yml:
+the two workflows call the engine directly, so without this a trial ran with different
+flags than the sweep it is meant to predict.
+
+    mapfile -t args < <(python3 scripts/autobump-args.py <category/package>)
+    python3 scripts/autobump-args.py --describe <category/package>   # one phrase for the issue comment
+
+Exit 2 with a reason when the table asks for something the engine cannot honour.
+"""
+import sys
+import tomllib
+
+DEFAULT_TOML = ".github/workflows/overlay.toml"
+
+
+def die(reason):
+    print(reason, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def keep_old_flag(pkg, value):
+    """`autobump` carries the retention: true replaces, N keeps N, "all" keeps every one."""
+    if value in (None, True, False, 0):
+        return []
+    if value == "all":
+        return ["--keep-old"]
+    if isinstance(value, int) and value > 0:
+        return [f"--keep-old={value}"]
+    die(f"{pkg}: unsupported autobump value {value!r}")
+
+
+def rewrite_flags(pkg, table):
+    """`autobump_<variable>_regex` names the ebuild variable to rewrite in its own key."""
+    names = sorted(k[len("autobump_"):-len("_regex")]
+                   for k in table if k.startswith("autobump_") and k.endswith("_regex"))
+    if not names:
+        return []
+    if len(names) > 1:
+        die(f"{pkg}: {len(names)} rewrite specs but the engine takes one")
+    name = names[0]
+    url = table.get(f"autobump_{name}_url") or table.get("url")
+    if not url:
+        die(f"{pkg}: rewrite of {name.upper()} has no url, and the entry has none to fall back on")
+    return ["--rewrite-var", name.upper(),
+            "--rewrite-url", url,
+            "--rewrite-regex", table[f"autobump_{name}_regex"]]
+
+
+def describe(flags):
+    """The same settings in words, for the status comment autobump leaves on the issue."""
+    said = []
+    for flag in flags:
+        if flag == "--keep-old":
+            said.append("keeps every old version")
+        elif flag.startswith("--keep-old="):
+            said.append(f"keeps {flag.removeprefix('--keep-old=')} old versions")
+        elif flag == "--rewrite-var":
+            said.append("rewrites a pinned variable")
+    return "".join(f" · {s}" for s in said)
+
+
+def main(argv):
+    argv = argv[1:]
+    as_words = argv and argv[0] == "--describe"
+    if as_words:
+        argv = argv[1:]
+    pkg = argv[0]
+    path = argv[1] if len(argv) > 1 else DEFAULT_TOML
+    with open(path, "rb") as f:
+        table = tomllib.load(f).get(pkg, {})
+    flags = keep_old_flag(pkg, table.get("autobump")) + rewrite_flags(pkg, table)
+    print(describe(flags) if as_words else "\n".join(flags))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/autobump-discover.sh
+++ b/scripts/autobump-discover.sh
@@ -32,7 +32,7 @@ excluded() {  # already decided -- whitelisted (autobump = true) OR deliberately
     awk -v w="[\"$1\"]" '
         {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
         h==w{f=1;next}/^\[/{f=0}
-        f&&/autobump = true/{e=1}
+        f&&h~/^[[:space:]]*autobump[[:space:]]*=/&&h!~/=[[:space:]]*false/{e=1}
         f&&/#[[:space:]]*autobump[[:space:]]+off/{e=1}
         END{exit !e}' "$TOML" 2>/dev/null
 }

--- a/scripts/autobump-probe.sh
+++ b/scripts/autobump-probe.sh
@@ -36,7 +36,8 @@ done
 autobump_enabled() {
     awk -v want="[\"$1\"]" '
         {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
-        h==want{f=1;next}/^\[/{f=0}f&&/^[[:space:]]*autobump[[:space:]]*=[[:space:]]*true/{e=1}END{exit !e}' \
+        h==want{f=1;next}/^\[/{f=0}
+        f&&h~/^[[:space:]]*autobump[[:space:]]*=/&&h!~/=[[:space:]]*false/{e=1}END{exit !e}' \
         .github/workflows/overlay.toml
 }
 
@@ -64,10 +65,12 @@ for n in "${ISSUES[@]}"; do
     autobump_disabled "$pkg" && continue    # deliberately off -- keep it out of the recommendation
     tag=""; autobump_enabled "$pkg" && tag=" [opted-in]"
 
-    $ENGINE "$n" --check >/dev/null 2>&1; ec=$?
+    ab_args=$(python3 scripts/autobump-args.py "$pkg" 2>/dev/null) || ab_args=""
+    AB_ARGS=(); [ -n "$ab_args" ] && mapfile -t AB_ARGS <<<"$ab_args"
+    $ENGINE "$n" --check "${AB_ARGS[@]}" >/dev/null 2>&1; ec=$?
     case "$ec" in
     0)  if [ "$DEEP" = 1 ]; then
-            $ENGINE "$n" --diff-only >/dev/null 2>&1; dc=$?
+            $ENGINE "$n" --diff-only "${AB_ARGS[@]}" >/dev/null 2>&1; dc=$?
             case "$dc" in
             0) CAND+=("#$n  $pkg -> $ver$tag") ;;
             3) ESC+=("#$n  $pkg -> $ver: surface/vendor changed (--diff-only)$tag") ;;

--- a/scripts/autobump-sweep.sh
+++ b/scripts/autobump-sweep.sh
@@ -60,7 +60,7 @@ declare -A STATUS_COMMENT_FAILED
 # run the judge from a copy: the engine switches branches, and if the script only
 # exists on the current branch it would vanish mid-sweep
 TOOLS=$(mktemp -d /tmp/autobump-tools-XXXX)
-cp scripts/autobump-judge.sh "$TOOLS/"
+cp scripts/autobump-judge.sh scripts/autobump-args.py "$TOOLS/"
 # AUTOBUMP_ENGINE points at the engine (e.g. "ruby .../autobump-rb/bin/autobump"). Required:
 # autobump-rb is the single engine, there is no in-tree fallback to default to.
 ENGINE=${AUTOBUMP_ENGINE:?set AUTOBUMP_ENGINE, e.g. ruby autobump-rb/bin/autobump}
@@ -104,8 +104,9 @@ status_comment() {  # $1=issue $2=body ; edit the bot's marked comment in place,
     STATUS_COMMENT_FAILED[$n]=1
 }
 
-# opt-in whitelist: only bump packages a maintainer marked `autobump = true` in the
-# nvchecker config, so which packages are trusted for auto-bumping is an explicit choice.
+# opt-in whitelist: only bump packages a maintainer marked `autobump` in the nvchecker
+# config, so which packages are trusted for auto-bumping is an explicit choice. The value
+# carries the retention (true, N, "all"); autobump-args.py turns it into engine flags.
 # TOML permits a trailing comment after a table header (`["cat/pkg"] # note`); strip an
 # inline comment + trailing space before the exact-match compare, else an opted-in package
 # with a commented header is silently skipped as not-opted-in.
@@ -114,23 +115,8 @@ autobump_enabled() {
         {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
         h==want {in_pkg=1; next}
         /^\[/   {in_pkg=0}
-        in_pkg && /^[[:space:]]*autobump[[:space:]]*=[[:space:]]*true/ {found=1; exit}
+        in_pkg && h ~ /^[[:space:]]*autobump[[:space:]]*=/ && h !~ /=[[:space:]]*false/ {found=1; exit}
         END {exit !found}
-    ' .github/workflows/overlay.toml
-}
-
-# keep-old opt-in: a package that must KEEP older versions (a real multi-version slot, or an
-# upstream that leaves old distfiles fetchable) marks `keep_old = N`; the sweep forwards
-# --keep-old=N so the engine keeps the N most-recent versions (0 or true = keep all). Independent
-# of autobump (a package is only swept when opted in); same header-match + inline-comment strip.
-keep_old_value() {  # print the package's keep_old value (true, or an integer N), else nothing
-    awk -v want="[\"$1\"]" '
-        {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
-        h==want {in_pkg=1; next}
-        /^\[/   {in_pkg=0}
-        in_pkg && /^[[:space:]]*keep_old[[:space:]]*=/ {
-            v=h; sub(/^[^=]*=[[:space:]]*/,"",v); print v; exit   # h already had the inline comment + trailing space stripped
-        }
     ' .github/workflows/overlay.toml
 }
 
@@ -144,20 +130,16 @@ for n in "${ISSUES[@]}"; do
     pkg=$(sed -nE 's/^\[nvchecker\] ([a-z0-9-]+\/[A-Za-z0-9_.+-]+) can be bump to .*/\1/p' <<<"$title")
     ver=$(sed -nE 's/.* can be bump to ([A-Za-z0-9._+-]+)$/\1/p' <<<"$title")
     if [ -z "$pkg" ] || [ -z "$ver" ]; then RESULT[$n]="unparseable title"; continue; fi
-    if ! autobump_enabled "$pkg"; then RESULT[$n]="skip (not opted in: no autobump=true)"; continue; fi
-    # unquoted below (like $PR) so an empty value word-splits away instead of passing a literal ''
-    KEEP_OLD=""; kov=$(keep_old_value "$pkg")
-    case "$kov" in
-        true)   KEEP_OLD="--keep-old" ;;         # keep all prior versions
-        [0-9]*) KEEP_OLD="--keep-old=$kov" ;;     # keep the N most-recent versions
-    esac
-    # opt-in marker appended to every status comment for this issue, so watchers can see at a
-    # glance that the package is auto-managed (and whether old versions are kept).
-    AB_FOOTER="— \`autobump\` enabled"
-    case "$kov" in
-        true|0) AB_FOOTER="$AB_FOOTER · keep_old=all" ;;
-        [1-9]*) AB_FOOTER="$AB_FOOTER · keep_old=$kov" ;;
-    esac
+    if ! autobump_enabled "$pkg"; then RESULT[$n]="skip (not opted in: no autobump key)"; continue; fi
+    # stderr is merged in: on refusal the script prints only the reason, so this is the reason
+    if ! ab_args=$(python3 "$TOOLS/autobump-args.py" "$pkg" 2>&1); then
+        RESULT[$n]="skip (${ab_args//$'\n'/ })"; continue
+    fi
+    # an array, because a rewrite regex may contain anything but a newline
+    AB_ARGS=()
+    [ -n "$ab_args" ] && mapfile -t AB_ARGS <<<"$ab_args"
+    # every status comment for this issue says the package is auto-managed, and with what
+    AB_FOOTER="— \`autobump\` enabled$(python3 "$TOOLS/autobump-args.py" --describe "$pkg")"
 
     if prior=$(grep -m1 -F "$pkg $ver " "$DONE"); then
         RESULT[$n]="skip ($prior)"; continue
@@ -166,7 +148,7 @@ for n in "${ISSUES[@]}"; do
     attempts=$((attempts + 1))
     echo "==== #$n $pkg -> $ver ($attempts/$LIMIT) ===="
     status_comment "$n" "**autobump** is bumping \`$pkg\` → \`$ver\`…$(run_link)"
-    out=$($ENGINE "$n" $KEEP_OLD $PR 2>&1); ec=$?
+    out=$($ENGINE "$n" "${AB_ARGS[@]}" $PR 2>&1); ec=$?
     # on success the tail is enough. on failure print everything: the engine's evidence dir is
     # inside the CI container and dies with it, so this log is the only postmortem material left.
     if [ "$ec" = 0 ]; then
@@ -213,7 +195,7 @@ for n in "${ISSUES[@]}"; do
         fi
         verdict=$(jq -r .verdict <<<"$verdict_json")
         if [ "$verdict" = proceed ]; then
-            out2=$($ENGINE "$n" --accept-surface --accept-payload $KEEP_OLD $PR 2>&1); ec2=$?
+            out2=$($ENGINE "$n" --accept-surface --accept-payload "${AB_ARGS[@]}" $PR 2>&1); ec2=$?
             echo "$out2" | tail -3
             if [ "$ec2" = 0 ]; then
                 echo "$pkg $ver bumped-after-judge $(date +%F)" >> "$DONE"

--- a/scripts/autobump.md
+++ b/scripts/autobump.md
@@ -61,9 +61,36 @@ autobump = true          # add to enable, remove to disable
 Packages without the line are never bumped, so removing it is how you stop one that
 keeps opening bad PRs.
 
-`keep_old = N` alongside it keeps the N most recent versions instead of replacing the
-top one. `app-misc/go-yq-bin` and `media-fonts/sarasa-gothic` use `keep_old = 2`;
-`keep_old = 0` keeps every version.
+The value of `autobump` also says how many old versions to keep: `true` replaces, `N` keeps the
+N most recent, `"all"` keeps every one.
+
+## Packages whose SRC_URI depends on an ebuild variable
+
+`app-editors/cursor` builds `SRC_URI` from `MY_COMMIT`, so a version-only copy fetches nothing.
+One regex makes autobump replace that variable after it copies the ebuild and before it
+regenerates the Manifest:
+
+```toml
+["app-editors/cursor"]
+source = "regex"
+url = "https://cursor.com/api/download?platform=linux-x64&releaseTrack=latest"
+regex = '"version":"([\d.]+)"'
+autobump = true
+autobump_my_commit_regex = '"commitSha":"([0-9a-f]{40})"'
+```
+
+The `my_commit` in the key is `MY_COMMIT`, the value is capture group 1, and the document
+defaults to the entry's own `url`. Both accept `${PV}`, replaced with the version being bumped
+to:
+
+```toml
+autobump_my_build_regex = '"version":"${PV}","execution_id":"([0-9]+)"'
+autobump_my_build_url = "https://example.org/releases/${PV}"
+```
+
+Write the regex as a TOML literal (single-quoted) string. If the document cannot be fetched, the
+regex does not match, or the value equals the current one, nothing is rewritten and nothing is
+bumped.
 
 ## Running it
 

--- a/scripts/autobump.zh.md
+++ b/scripts/autobump.zh.md
@@ -48,7 +48,29 @@ autobump = true          # 添加此行开启，删除即关闭
 
 没有这一行的包不会被 bump，所以某个包频繁产生错误的 PR 时，删掉这行就能停掉它。
 
-再加一行 `keep_old = N`，bump 时就保留最近 N 个版本，而不是只替换最新那一个。`app-misc/go-yq-bin` 和 `media-fonts/sarasa-gothic` 用 `keep_old = 2`；`keep_old = 0` 表示保留全部版本。
+`autobump` 的值同时指定旧版本保留数：`true` 不保留，`N` 保留最近 N 个，`"all"` 保留全部。
+
+## SRC_URI 依赖 ebuild 变量的包
+
+`app-editors/cursor` 的 `SRC_URI` 由 `MY_COMMIT` 构造。仅改版本号无法获取文件。配置正则后，`autobump` 在复制 ebuild 后、生成 Manifest 前替换该变量：
+
+```toml
+["app-editors/cursor"]
+source = "regex"
+url = "https://cursor.com/api/download?platform=linux-x64&releaseTrack=latest"
+regex = '"version":"([\d.]+)"'
+autobump = true
+autobump_my_commit_regex = '"commitSha":"([0-9a-f]{40})"'
+```
+
+`autobump_my_commit_regex` 中的 `my_commit` 对应 ebuild 变量 `MY_COMMIT`，值取第一个捕获组，默认从该条目的 `url` 获取。正则和 URL 都支持 `${PV}`，替换为目标版本：
+
+```toml
+autobump_my_build_regex = '"version":"${PV}","execution_id":"([0-9]+)"'
+autobump_my_build_url = "https://example.org/releases/${PV}"
+```
+
+正则使用 TOML 单引号字面字符串。无法读取值、正则不匹配或新值与旧值相同时，不改写 ebuild，也不 bump。
 
 ## 运行
 


### PR DESCRIPTION
因为 `autobump-trial` 和 `autobump-recommend` 直接调用引擎、不经过 sweep，所以每包设置在 trial 里从未生效；四个调用方改用同一个解析脚本 `scripts/autobump-args.sh`。

保留策略并进 `autobump` 的值：`true` 只替换，`N` 保留最近 N 个，`"all"` 全部保留，五个用 `keep_old` 的包一并迁移，AGENTS.md 同步。

`app-editors/cursor` 是第一个用变量改写的包（autobump-rb#11）：`SRC_URI` 由 `MY_COMMIT` 拼出，条目已有的接口回应带 `commitSha`，加一行 `autobump_my_commit_regex` 即可。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
