### PR TITLE
net-proxy/sing-box: enable autobump

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2347,6 +2347,7 @@ github = "SagerNet/sing-box"
 use_latest_release = true
 prefix = "v"
 github_account = "Puqns67"
+autobump = true
 
 ["net-proxy/sing-box-windows-bin"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2274,6 +2274,7 @@ github = "chen08209/FlClash"
 use_latest_release = true
 prefix = "v"
 github_account = ["yangmame", "peeweep"]
+autobump = true
 
 ["net-proxy/hysteria"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -712,6 +712,7 @@ github = "HalFrgrd/flyline"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
 
 ["app-shells/gentoo-fish-completion"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2220,6 +2220,7 @@ github = "c0re100/qBittorrent-Enhanced-Edition"
 use_latest_release = true
 prefix = "release-"
 github_account = "gouwazi"
+autobump = true
 
 # TODO: upstream no tags
 #["net-print/epson-inkjet-printer_201207w"]

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1215,6 +1215,7 @@ github = "modem-dev/hunk"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
 
 # TODO:
 # https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2774,6 +2774,7 @@ github = "bikass/kora"
 use_latest_release = true
 prefix = "v"
 github_account = ["Nuralii1i", "gouwazi"]
+autobump = true
 
 ["x11-themes/mint-themes"]
 source = "github"


### PR DESCRIPTION
六个包的最近 bump 几乎只改版本号，各自跑过一次 `--diff-only` 重放：判为机械 bump，取档与 Manifest 通过，有 build-option surface 的也无变化。

历史比例分别是 sing-box 8/8、flclash-bin 8/10、kora-icon-theme 6/8、hunk-bin 4/5、flyline-bin 5/7、qbittorrent-enhanced 5/7。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
