### PR TITLE
overlay.toml: keep app-admin/1password off autobump

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2451,6 +2451,7 @@ source = "regex"
 url = "https://lceda.cn/page/download?src=index"
 regex = "lceda-pro-linux-x64-([\\d.]+).zip"
 github_account = ["123485k", "gouwazi"]
+# autobump off: upstream host times out from CI too
 
 ["sci-electronics/openfpgaloader"]
 source = "github"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -54,6 +54,7 @@ mirror = "https://downloads.1password.com/linux/debian/amd64"
 suite = "stable"
 # strip_release = true
 github_account = ["yangmame", "peeweep", "gouwazi"]
+# autobump off: install needs acct-group/onepassword, which the engine lacks
 
 ["app-admin/chezmoi"]
 source = "github"


### PR DESCRIPTION
两个包无法自动 bump，补上标记，否则 `autobump-discover` 每轮都会把它们当成从未决定过重新推荐。

`app-admin/1password` 的 `src_install` 用 `fowners root:onepassword`，而引擎的 install 流程没有 `acct-group/onepassword`，每次都卡在 build gate，PR #12611 已据此关闭但没留标记。`sci-electronics/lceda-pro` 的上游主机在 GitHub runner 上同样连接超时，最近三个 PR 的版本化 emerge check 都因取档失败而红。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
