### PR TITLE
overlay.toml: track app-admin/chezmoi-bin again, without the GraphQL clash

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -931,6 +931,12 @@ github_account = ["blackteahamburger", "gouwazi"]
 # high update frequency
 #["dev-libs/v2ray-rules-dat-bin"]
 
+["dev-libs/v2ray-domain-list-community-bin"]
+source = "github"
+github = "v2fly/domain-list-community"
+use_latest_release = true
+github_account = "peeweep"
+
 ["dev-python/adafruit-board-toolkit"]
 source = "pypi"
 pypi = "adafruit-board-toolkit"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -937,6 +937,12 @@ github = "v2fly/domain-list-community"
 use_latest_release = true
 github_account = "peeweep"
 
+["dev-libs/v2ray-geoip-bin"]
+source = "github"
+github = "v2fly/geoip"
+use_latest_release = true
+github_account = "peeweep"
+
 ["dev-python/adafruit-board-toolkit"]
 source = "pypi"
 pypi = "adafruit-board-toolkit"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -69,6 +69,12 @@ prefix = "v"
 # use_latest_release = true
 # prefix = "v"
 
+["app-admin/chezmoi-bin"]
+source = "regex"
+url = "https://api.github.com/repos/twpayne/chezmoi/releases/latest"
+regex = '"tag_name":\s*"v([\d.]+)"'
+github_account = "peeweep"
+
 ["app-admin/enpass"]
 source = "apt"
 mirror = "https://apt.enpass.io"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -943,6 +943,12 @@ github = "v2fly/geoip"
 use_latest_release = true
 github_account = "peeweep"
 
+["dev-libs/v2ray-rules-dat-bin"]
+source = "github"
+github = "Loyalsoldier/v2ray-rules-dat"
+use_latest_release = true
+github_account = "peeweep"
+
 ["dev-python/adafruit-board-toolkit"]
 source = "pypi"
 pypi = "adafruit-board-toolkit"


### PR DESCRIPTION
因为 nvchecker 的 GitHub source 走 GraphQL，同一个仓库的两个条目会互相污染，所以 `app-admin/chezmoi-bin` 当初被注释掉，只追源码包 `chezmoi`（见文件里那条 FIXME）。

改用 `source = "regex"` 打 REST 的 releases 接口即可避开。本地跑过 nvchecker，两个条目同时解出 2.72.1：`chezmoi` 按 tag，`chezmoi-bin` 按 release。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
