### PR TITLE
autobump: reuse the daily environment image and run the whole queue

### DIFF
--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -1,17 +1,29 @@
 # Build the bump workers' environment image (see .github/autobump-env/Dockerfile).
 #
-# autobump.yml calls this every run, so the tooling matches the tree the workers sync.
-# Tagged per ref, so a branch test does not overwrite the image scheduled runs pull.
+# autobump.yml calls this every run, but the image is tagged by ref and date, so only the
+# first run of a day builds and the rest reuse it - a day is as stale as the tooling may get
+# against the tree the workers sync. Tagging by ref keeps a branch test off the image the
+# scheduled runs pull.
 
 name: autobump-env
 
 on:
   workflow_call:
+    inputs:
+      force:
+        description: rebuild even if today's image exists
+        type: boolean
+        default: false
     outputs:
       image:
         description: the image the bump workers run in
         value: ${{ jobs.build.outputs.image }}
   workflow_dispatch:
+    inputs:
+      force:
+        description: rebuild even if today's image exists
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -37,7 +49,7 @@ jobs:
       run: |
         owner=$(printf '%s' "$OWNER" | tr 'A-Z' 'a-z')
         tag=$(printf '%s' "$REF" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9._-' '-')
-        echo "ref=ghcr.io/$owner/autobump-env:$tag" >> "$GITHUB_OUTPUT"
+        echo "ref=ghcr.io/$owner/autobump-env:$tag-$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
     - name: log in to ghcr
       uses: docker/login-action@v3
@@ -46,8 +58,18 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: look for today's image
+      id: existing
+      env:
+        REF: ${{ steps.image.outputs.ref }}
+      run: |
+        if docker manifest inspect "$REF" > /dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        fi
+
     # no build cache: the point of rebuilding is to pick up today's tree and binpkgs
     - name: build and push
+      if: ${{ inputs.force || steps.existing.outputs.exists != 'true' }}
       uses: docker/build-push-action@v6
       with:
         context: .github/autobump-env

--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -76,3 +76,13 @@ jobs:
         push: true
         no-cache: true
         tags: ${{ steps.image.outputs.ref }}
+
+    # a day's image supersedes the one before it and nothing removes the old one; keep a
+    # few so a worker still pulling one is unaffected
+    - name: drop superseded images
+      uses: actions/delete-package-versions@v5
+      with:
+        owner: ${{ github.repository_owner }}
+        package-name: autobump-env
+        package-type: container
+        min-versions-to-keep: 3

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -42,9 +42,13 @@ on:
         required: false
         default: ''
       limit:
-        description: 'max issues per run'
+        description: 'max issues per run (0 = the whole queue)'
         required: false
-        default: '30'
+        default: '0'
+      rebuild_env:
+        description: 'rebuild the worker environment image'
+        type: boolean
+        default: false
 
 concurrency:
   group: autobump
@@ -79,6 +83,8 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/autobump-env.yml
+    with:
+      force: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_env }}
 
   # plan and collect need python3 and gh, both on the runner image; only the bump workers
   # need portage, and a container start costs a 3.5 GB pull.
@@ -114,7 +120,7 @@ jobs:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
         XDG_STATE_HOME: ${{ github.workspace }}/.autobump-state
         ISSUES: ${{ github.event.inputs.issues }}
-        LIMIT: ${{ github.event.inputs.limit || 30 }}
+        LIMIT: ${{ github.event.inputs.limit || 0 }}
         SHARDS: '8'
       run: |
         # validate before use: ISSUES is space-separated issue numbers, LIMIT and SHARDS are ints.
@@ -249,7 +255,7 @@ jobs:
         AUTOBUMP_EVIDENCE_DIR: /tmp/autobump-evidence
         SHARD: ${{ toJSON(fromJSON(needs.plan.outputs.plan).shards[matrix.shard]) }}
         SHARD_ID: ${{ matrix.shard }}
-        LIMIT: ${{ github.event.inputs.limit || 30 }}
+        LIMIT: ${{ github.event.inputs.limit || 0 }}
       run: python3 scripts/autobump-sweep.py --worker "$SHARD" --delta "autobump-delta-$SHARD_ID.json" --limit "$LIMIT" --pr --comment
 
     - name: save dependency binpkgs

--- a/scripts/autobump-sweep.py
+++ b/scripts/autobump-sweep.py
@@ -139,7 +139,7 @@ def parse_args(argv):
     parsed = {
         "pr": "",
         "comment": False,
-        "limit": "5",
+        "limit": "0",
         "issues": [],
         "plan_shards": None,
         "worker": None,
@@ -222,6 +222,13 @@ def package_and_version(title):
         if version:
             versions.append(version.group(1))
     return "\n".join(packages), "\n".join(versions)
+
+
+def run_limit(settings):
+    # 0 is no cap: with the queue sharded across workers there is usually no reason to
+    # leave part of a day's issues for tomorrow.
+    limit = int(settings.limit)
+    return limit if limit > 0 else None
 
 
 def run_link(upstream_repo, label="run"):
@@ -506,7 +513,7 @@ def select_issues(settings):
             "--state",
             "open",
             "--limit",
-            str(int(settings.limit) * 10),
+            str((run_limit(settings) or 20) * 10),
             "--json",
             "number",
             "--jq",
@@ -580,8 +587,9 @@ def plan_issues(settings, issues):
             results[issue] = result
             continue
 
-        if attempts >= int(settings.limit):
-            results[issue] = f"skip (per-run attempt limit {settings.limit} reached)"
+        cap = run_limit(settings)
+        if cap is not None and attempts >= cap:
+            results[issue] = f"skip (per-run attempt limit {cap} reached)"
             continue
 
         attempts += 1
@@ -796,7 +804,9 @@ def defer_transient(settings, issue, package, version, engine_output, footer, st
 
 
 def run_package(settings, tools, engine, issue, package, version, args, footer, attempt, status_comment_failed):
-    print(f"==== #{issue} {package} -> {version} ({attempt}/{settings.limit}) ====")
+    cap = run_limit(settings)
+    counter = f"{attempt}/{cap}" if cap else str(attempt)
+    print(f"==== #{issue} {package} -> {version} ({counter}) ====")
     status_comment(
         issue,
         f"**autobump** is bumping `{package}` → `{version}`…{run_link(settings.upstream_repo)}",
@@ -822,8 +832,9 @@ def run_issues(settings, issues, apply_run_limit, tools, engine):
     status_comment_failed = set()
     attempts = 0
     for issue in issues:
-        if apply_run_limit and attempts >= int(settings.limit):
-            results[issue] = f"skip (per-run attempt limit {settings.limit} reached)"
+        cap = run_limit(settings)
+        if apply_run_limit and cap is not None and attempts >= cap:
+            results[issue] = f"skip (per-run attempt limit {cap} reached)"
             continue
 
         package, version, result = issue_bump_target(settings, issue)

--- a/scripts/autobump.md
+++ b/scripts/autobump.md
@@ -117,10 +117,11 @@ gh workflow run autobump.yml --repo gentoo-zh/overlay -f limit=20
 
 Both take the same inputs; `issues` accepts digits and spaces only.
 
-`limit` defaults to 30 and caps engine attempts across the whole run. The planner resolves the
-queue against the cached state and assigns those attempts to disjoint shards; skips are free.
+`limit` caps engine attempts across the whole run; it defaults to 0, which runs the whole
+queue. The planner resolves the queue against the cached state and assigns those attempts to
+disjoint shards; skips are free.
 
-A run has three phases: plan, at most three bump workers in parallel, and collect. Each worker
+A run has three phases: plan, at most eight bump workers in parallel, and collect. Each worker
 lasts at most 360 minutes and GitHub cancels it there. Each package has a separate two-hour
 ceiling: `ebuild install`, `emerge` and `ebuild unpack` are deferred on timeout and retried next
 run.

--- a/scripts/autobump.zh.md
+++ b/scripts/autobump.zh.md
@@ -95,9 +95,9 @@ gh workflow run autobump.yml --repo gentoo-zh/overlay -f limit=20
 
 两种方式的输入相同，`issues` 只接受数字和空格。
 
-`limit` 默认 30，限制整次运行的引擎尝试总数。规划阶段按缓存状态解析队列，把这些尝试分到互不重叠的 shard，跳过不占额度。
+`limit` 限制整次运行的引擎尝试总数，默认 0 表示整个队列都跑。规划阶段按缓存状态解析队列，把这些尝试分到互不重叠的 shard，跳过不占额度。
 
-一次运行分三段：规划、最多三个并行的 bump worker、合并。每个 worker 最多 360 分钟，到时由 GitHub 取消。单个包另有两小时上限，`ebuild install`、`emerge` 和 `ebuild unpack` 超时后标记暂缓，下次重试。
+一次运行分三段：规划、最多八个并行的 bump worker、合并。每个 worker 最多 360 分钟，到时由 GitHub 取消。单个包另有两小时上限，`ebuild install`、`emerge` 和 `ebuild unpack` 超时后标记暂缓，下次重试。
 
 本地运行先把引擎 clone 到 overlay 根目录、安装 `dev-lang/ruby`：
 

--- a/test/test_autobump_sweep.py
+++ b/test/test_autobump_sweep.py
@@ -426,7 +426,7 @@ class AutobumpSweepTest(unittest.TestCase):
         self.assertIn("#7  skip (per-run attempt limit 2 reached)", collected.stdout)
 
     def test_single_job_invocation_keeps_existing_output(self):
-        result = self.run_sweep("3")
+        result = self.run_sweep("3", "--limit", "5")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
@@ -435,6 +435,16 @@ class AutobumpSweepTest(unittest.TestCase):
             "stage one\nhttps://github.com/test/overlay/pull/123\n\n"
             "==== sweep summary ====\n#3  bumped\n",
         )
+
+    def test_no_limit_runs_the_whole_queue(self):
+        result = self.run_sweep("3", "6")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # the header drops the "of N" when nothing caps the run
+        self.assertIn("==== #3 cat/bump -> 2.0 (1) ====", result.stdout)
+        self.assertIn("#3  bumped", result.stdout)
+        self.assertIn("#6  bumped", result.stdout)
+        self.assertNotIn("attempt limit", result.stdout)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
上线后第一轮跑完：8 个 worker 并行、全程 21 分钟、7 个 bumped 并开 PR。三个后续改动：

- 环境镜像按天复用。原本每次运行都重建，八个 worker 要等 14 分钟才拿到和上一轮完全相同的镜像。镜像 tag 加日期，env job 先查今天的在不在，在就跳过构建。手动运行多了一个「rebuild the worker environment image」勾选，勾了强制重建。
- 清理旧镜像。每天的镜像取代前一天的，旧的不会有人删，构建后保留最近三个。
- `limit` 默认改为 0，即跑完整个队列。这个上限是单 job 顺序处理时代的产物，现在队列按 shard 分给多个 worker，一天的 issue 一轮就能跑完；输入框保留，手动限量仍然可用。

测试：`test/test_autobump_sweep.py` 19 个全过，新增一个覆盖无上限路径（标题从 `(1/5)` 变 `(1)`，不再出现 attempt limit 跳过）。镜像复用和勾选项在合并后的第一轮运行可以直接看到效果。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
