### PR TITLE
autobump: pick the environment image and stop over-waiting

### DIFF
--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -14,6 +14,10 @@ on:
         description: rebuild even if today's image exists
         type: boolean
         default: false
+      date:
+        description: use the image of an earlier day (YYYYMMDD); it must still be kept
+        type: string
+        default: ''
     outputs:
       image:
         description: the image the bump workers run in
@@ -24,6 +28,10 @@ on:
         description: rebuild even if today's image exists
         type: boolean
         default: true
+      date:
+        description: use the image of an earlier day (YYYYMMDD); it must still be kept
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -46,10 +54,13 @@ jobs:
       env:
         OWNER: ${{ github.repository_owner }}
         REF: ${{ github.ref_name }}
+        DAY: ${{ inputs.date }}
       run: |
+        case "$DAY" in ''|[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]) ;;
+          *) echo "date must be YYYYMMDD: $DAY" >&2; exit 1;; esac
         owner=$(printf '%s' "$OWNER" | tr 'A-Z' 'a-z')
         tag=$(printf '%s' "$REF" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9._-' '-')
-        echo "ref=ghcr.io/$owner/autobump-env:$tag-$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+        echo "ref=ghcr.io/$owner/autobump-env:$tag-${DAY:-$(date -u +%Y%m%d)}" >> "$GITHUB_OUTPUT"
 
     - name: log in to ghcr
       uses: docker/login-action@v3
@@ -58,18 +69,25 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: look for today's image
+    - name: look for the image
       id: existing
       env:
         REF: ${{ steps.image.outputs.ref }}
+        DAY: ${{ inputs.date }}
       run: |
         if docker manifest inspect "$REF" > /dev/null 2>&1; then
           echo "exists=true" >> "$GITHUB_OUTPUT"
+        elif [ -n "$DAY" ]; then
+          # an earlier day cannot be rebuilt: the tree and binpkgs it was built from are
+          # gone, and building today's under its tag would be a lie. Only three are kept.
+          echo "no image for $DAY: $REF" >&2
+          exit 1
         fi
 
     # no build cache: the point of rebuilding is to pick up today's tree and binpkgs
     - name: build and push
-      if: ${{ inputs.force || steps.existing.outputs.exists != 'true' }}
+      id: build
+      if: ${{ inputs.date == '' && (inputs.force || steps.existing.outputs.exists != 'true') }}
       uses: docker/build-push-action@v6
       with:
         context: .github/autobump-env
@@ -80,6 +98,7 @@ jobs:
     # a day's image supersedes the one before it and nothing removes the old one; keep a
     # few so a worker still pulling one is unaffected
     - name: drop superseded images
+      if: steps.build.outcome == 'success'
       uses: actions/delete-package-versions@v5
       with:
         owner: ${{ github.repository_owner }}

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -74,9 +74,12 @@ jobs:
         echo "nvchecker concluded ${{ github.event.workflow_run.conclusion }}; nothing to bump" >&2
         exit 1
 
+    # nvchecker files the issues inside its own run, so they exist by the time this fires.
+    # The wait is for the search index the queue is read through, which can trail a new
+    # issue by a few minutes.
     - name: wait for the issues to settle
       if: github.event_name == 'workflow_run'
-      run: sleep 1800
+      run: sleep 300
 
   # After plan, so a run with an empty queue builds nothing; the 13 minutes this adds
   # ahead of the workers are nothing against a run that bumps for hours.

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -49,6 +49,10 @@ on:
         description: 'rebuild the worker environment image'
         type: boolean
         default: false
+      env_date:
+        description: 'run on an earlier environment image (YYYYMMDD, empty = today)'
+        required: false
+        default: ''
 
 concurrency:
   group: autobump
@@ -85,6 +89,7 @@ jobs:
     uses: ./.github/workflows/autobump-env.yml
     with:
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_env }}
+      date: ${{ inputs.env_date || '' }}
 
   # plan and collect need python3 and gh, both on the runner image; only the bump workers
   # need portage, and a container start costs a 3.5 GB pull.

--- a/scripts/autobump.md
+++ b/scripts/autobump.md
@@ -95,7 +95,7 @@ bumped.
 
 ## Running it
 
-It runs 30 minutes after each nvchecker run finishes, once the issues are filed, and daily
+It runs 5 minutes after each nvchecker run finishes, once the issues are filed, and daily
 at 11:00 UTC as a backstop.
 
 ### Web

--- a/scripts/autobump.md
+++ b/scripts/autobump.md
@@ -117,6 +117,9 @@ gh workflow run autobump.yml --repo gentoo-zh/overlay -f limit=20
 
 Both take the same inputs; `issues` accepts digits and spaces only.
 
+The workers run in an image built once a day (`autobump-env`). `rebuild_env` forces a fresh
+one; `env_date` runs on an earlier day's image, of which the last three are kept.
+
 `limit` caps engine attempts across the whole run; it defaults to 0, which runs the whole
 queue. The planner resolves the queue against the cached state and assigns those attempts to
 disjoint shards; skips are free.

--- a/scripts/autobump.zh.md
+++ b/scripts/autobump.zh.md
@@ -95,6 +95,8 @@ gh workflow run autobump.yml --repo gentoo-zh/overlay -f limit=20
 
 两种方式的输入相同，`issues` 只接受数字和空格。
 
+worker 跑在每天构建一次的镜像里（`autobump-env`）。`rebuild_env` 强制重建，`env_date` 指定用更早一天的镜像，保留最近三个。
+
 `limit` 限制整次运行的引擎尝试总数，默认 0 表示整个队列都跑。规划阶段按缓存状态解析队列，把这些尝试分到互不重叠的 shard，跳过不占额度。
 
 一次运行分三段：规划、最多八个并行的 bump worker、合并。每个 worker 最多 360 分钟，到时由 GitHub 取消。单个包另有两小时上限，`ebuild install`、`emerge` 和 `ebuild unpack` 超时后标记暂缓，下次重试。

--- a/scripts/autobump.zh.md
+++ b/scripts/autobump.zh.md
@@ -74,7 +74,7 @@ autobump_my_build_url = "https://example.org/releases/${PV}"
 
 ## 运行
 
-每次 nvchecker 跑完 30 分钟后执行；另有每天 11:00 UTC 一次作为兜底。
+每次 nvchecker 跑完 5 分钟后执行；另有每天 11:00 UTC 一次作为兜底。
 
 ### 网页
 


### PR DESCRIPTION
两个改动：

- 手动运行可以指定用更早一天的环境镜像。表单新增 `env_date`（八位日期，空白＝今天），配合保留三个镜像的策略，可用范围是今天、昨天、前天；今天的工具链有问题时可以退回去跑。指定旧日期时只查不建：那天的 tree 和 binpkg 已经不在，把今天的内容贴上旧 tag 是骗人，镜像不在就直接失败并打印找不到的 tag。清理旧镜像的步骤加了条件，没有构建就不删。
- nvchecker 之后的等待从 30 分钟改成 5 分钟。issue 是 nvchecker 自己那次运行里的 issues-bumper job 开的，运行结束时已经存在，等待从来不是为了等它们被创建。真正要覆盖的是队列所读的搜索索引对新 issue 的滞后，最坏几分钟。

自动触发已经在生产验证：nvchecker run 33648598243 结束后，autobump run 33649145452 以 workflow_run 自动开起来。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
