### PR TITLE
autobump: keep three days of images, not three versions

### DIFF
--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -75,10 +75,24 @@ jobs:
         context: .github/autobump-env
         push: true
         no-cache: true
+        # a plain image, not an index with attestation manifests: those show up as untagged
+        # versions that belong to the image, and the cleanup below removes untagged versions
+        provenance: false
         tags: ${{ steps.image.outputs.ref }}
 
-    # a day's image supersedes the one before it and nothing removes the old one; keep a
-    # few so a worker still pulling one is unaffected
+    # rebuilding a day leaves the version it replaced untagged; it is nobody's image and
+    # would otherwise take one of the three slots below
+    - name: drop replaced images
+      uses: actions/delete-package-versions@v5
+      with:
+        owner: ${{ github.repository_owner }}
+        package-name: autobump-env
+        package-type: container
+        delete-only-untagged-versions: true
+        min-versions-to-keep: 0
+
+    # a day's image supersedes the one before it and nothing removes the old one; keep three
+    # days so a worker still pulling an earlier one is unaffected
     - name: drop superseded images
       uses: actions/delete-package-versions@v5
       with:


### PR DESCRIPTION
保留策略按版本数计，而重建一天会把被取代的那版留成 untagged，于是一次重建就占掉三个名额里的一个，把最早那天挤了出去；能用 `env_date` 回退的范围因此少一天。

改为先删 untagged，再按版本保留三个，三个名额就都是有 tag 的日期。

同时给构建加 `provenance: false`：默认会推一个带 attestation 的 index，那些 attestation 在 GHCR 里也是 untagged 版本，属于镜像本体，第一步会把镜像删坏。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
