### PR TITLE
autobump: move the docker actions off Node 20

### DIFF
--- a/.github/autobump-env/Dockerfile
+++ b/.github/autobump-env/Dockerfile
@@ -1,42 +1,27 @@
-# The bump workers' environment: the portage config, trust keys and ~80 tooling packages
-# every worker needs, installed once here instead of ~9.5 min per worker.
-#
-# The tree is removed in the layer that fetched it - the workers webrsync their own, so a
-# copy in the image is weight nobody reads.
+# The bump workers' environment, built once instead of ~9.5 min per worker. The tree goes
+# out in the layer that fetched it: the workers webrsync their own.
 FROM gentoo/stage3:amd64-desktop-openrc
 
 RUN emerge-webrsync --no-pgp-verify \
  && { \
-      # FEATURES keeps its ${...} so portage appends to the stage3 defaults. MAKEOPTS and
-      # CPU_FLAGS_X86 are not set here: they depend on the runner, so the worker sets them.
+      # MAKEOPTS and CPU_FLAGS_X86 describe the runner, so the worker sets those itself
       echo 'FEATURES="${FEATURES} getbinpkg buildpkg"'; \
       echo 'PORTAGE_ELOG_CLASSES="qa warn error"'; \
       echo 'PORTAGE_ELOG_SYSTEM="save"'; \
-      # accept all licenses: several opted-in packages are non-free (-bin blobs,
-      # CC-BY-NC, vendor EULAs). Without this emerge masks them and the bump churns
-      # its retries then defers with a misleading "build failure" comment, forever.
+      # several opted-in packages are non-free; masked ones defer as a "build failure"
       echo 'ACCEPT_LICENSE="*"'; \
     } >> /etc/portage/make.conf \
  && mkdir -p /etc/portage/package.use \
- # Align heavy-dep USE to the official binhost's binpkgs so getbinpkg actually USES them,
- # instead of rejecting a USE mismatch and rebuilding from source (which would blow the
- # op-timeout): the binhost builds webkit-gtk +keyring and qtwebengine +bindist, but the
- # desktop profile defaults them off. Keep this list in sync with emerge-on-pr's; extend
- # it if a heavy dep still shows [ebuild] in a real bump.
+ # match the binhost's USE or getbinpkg rejects its binpkgs and builds from source; keep
+ # in sync with emerge-on-pr's list
  && printf '%s\n' 'dev-qt/qtwebengine bindist' 'net-libs/webkit-gtk keyring' \
       > /etc/portage/package.use/ci-binhost \
- # Xvfb (minimal xorg-server) powers the advisory GUI launch probe: a GUI bump is
- # launched headless to see it does not crash on start. Drop the xorg-server line + this
- # package.use if the build cost is not worth it - the probe then just skips and the PR
- # still flags GUI apps for a manual check.
+ # Xvfb runs the GUI launch probe; dropping it only skips the probe
  && echo 'x11-base/xorg-server xvfb minimal -xorg' > /etc/portage/package.use/autobump-xvfb \
  && getuto \
  && install -dm775 -o root -g portage /var/cache/distfiles \
- # pkgdev/pkgcheck are dev-util/ now (pkgcore tools moved category); dev-lang/ruby runs
- # the engine. curl: the engine's finalize stage re-checks pkgcheck DeadUrl hits with it,
- # and stage3 ships only wget, so without it that probe crashes and defers the bump.
- # qlist (portage-utils) drives the --version smoke; qa-vdb (iwdevtools) checks RDEPEND
- # vs linked libs on source packages; cpuid2cpuflags is run per worker on its own CPU.
+ # curl because stage3 ships only wget and the DeadUrl recheck needs it; portage-utils for
+ # the --version smoke, iwdevtools for qa-vdb
  && emerge --quiet --getbinpkg --autounmask=y --autounmask-write=y --autounmask-continue=y \
       dev-lang/ruby dev-vcs/git dev-util/pkgdev dev-util/pkgcheck app-portage/portage-utils \
       app-portage/iwdevtools dev-util/github-cli app-misc/jq net-misc/curl \

--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -63,7 +63,7 @@ jobs:
         echo "ref=ghcr.io/$owner/autobump-env:$tag-${DAY:-$(date -u +%Y%m%d)}" >> "$GITHUB_OUTPUT"
 
     - name: log in to ghcr
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -88,7 +88,7 @@ jobs:
     - name: build and push
       id: build
       if: ${{ inputs.date == '' && (inputs.force || steps.existing.outputs.exists != 'true') }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .github/autobump-env
         push: true

--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -75,7 +75,8 @@ jobs:
         REF: ${{ steps.image.outputs.ref }}
         DAY: ${{ inputs.date }}
       run: |
-        if docker manifest inspect "$REF" > /dev/null 2>&1; then
+        # stdout is the manifest, stderr is why it is not there - keep the second
+        if docker manifest inspect "$REF" > /dev/null; then
           echo "exists=true" >> "$GITHUB_OUTPUT"
         elif [ -n "$DAY" ]; then
           # an earlier day cannot be rebuilt: the tree and binpkgs it was built from are

--- a/.github/workflows/autobump-env.yml
+++ b/.github/workflows/autobump-env.yml
@@ -1,9 +1,5 @@
-# Build the bump workers' environment image (see .github/autobump-env/Dockerfile).
-#
-# autobump.yml calls this every run, but the image is tagged by ref and date, so only the
-# first run of a day builds and the rest reuse it - a day is as stale as the tooling may get
-# against the tree the workers sync. Tagging by ref keeps a branch test off the image the
-# scheduled runs pull.
+# The bump workers' environment image, tagged by ref and date: one build a day, and a
+# branch test never overwrites what the scheduled runs pull.
 
 name: autobump-env
 
@@ -79,8 +75,7 @@ jobs:
         if docker manifest inspect "$REF" > /dev/null; then
           echo "exists=true" >> "$GITHUB_OUTPUT"
         elif [ -n "$DAY" ]; then
-          # an earlier day cannot be rebuilt: the tree and binpkgs it was built from are
-          # gone, and building today's under its tag would be a lie. Only three are kept.
+          # an earlier day cannot be rebuilt: its tree and binpkgs are gone
           echo "no image for $DAY: $REF" >&2
           exit 1
         fi
@@ -94,13 +89,11 @@ jobs:
         context: .github/autobump-env
         push: true
         no-cache: true
-        # a plain image, not an index with attestation manifests: those show up as untagged
-        # versions that belong to the image, and the cleanup below removes untagged versions
+        # no attestation manifests: the cleanup below deletes untagged versions
         provenance: false
         tags: ${{ steps.image.outputs.ref }}
 
-    # rebuilding a day leaves the version it replaced untagged; it is nobody's image and
-    # would otherwise take one of the three slots below
+    # rebuilding a day leaves the version it replaced untagged, taking a slot below
     - name: drop replaced images
       uses: actions/delete-package-versions@v5
       with:
@@ -110,8 +103,7 @@ jobs:
         delete-only-untagged-versions: true
         min-versions-to-keep: 0
 
-    # a day's image supersedes the one before it and nothing removes the old one; keep three
-    # days so a worker still pulling an earlier one is unaffected
+    # keep three days, the range env_date can fall back to
     - name: drop superseded images
       if: steps.build.outcome == 'success'
       uses: actions/delete-package-versions@v5

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,18 +1,13 @@
 # autobump: try the mechanical version bumps that nvchecker filed as issues.
 #
 # Design:
-# - Runs 30 minutes after each nvchecker run, so bumpbot has filed the issues.
-# - The plan job reads cached state once, resolves the queue and passes disjoint shards
-#   to workers. Workers never claim or share state; collect merges their deltas afterward.
-# - v1 uses NO model anywhere (AUTOBUMP_JUDGE is unset): whatever is not
-#   mechanically safe gets an evidence comment on its issue and stops.
-#   The judge hook exists in autobump-sweep.py for later, where semantic
-#   judgment is worth a cheap model call - it is optional by design.
-# - Mechanical bumps become normal PRs (draft when multi-arch), so the
-#   existing emerge-on-pr + pkgcheck CI re-verifies everything and a human
-#   is still the only merger.
-# - State (which pkg/version was already bumped or deferred) is cached so
-#   the daily run never redoes work.
+# - The plan job resolves the queue against cached state and hands workers disjoint shards;
+#   workers share no state and collect merges their deltas.
+# - No model anywhere while AUTOBUMP_JUDGE is unset: whatever is not mechanically safe gets
+#   an evidence comment on its issue and stops. The judge hook in autobump-sweep.py is for
+#   later, where semantic judgment is worth a cheap model call.
+# - Mechanical bumps become normal PRs (draft when multi-arch), so emerge-on-pr and pkgcheck
+#   re-verify everything and a human is still the only merger.
 #
 # Requires: repo setting "Allow GitHub Actions to create and approve pull
 # requests", and maintainer agreement that the bot pushes its topic branches
@@ -26,9 +21,8 @@
 name: autobump
 
 on:
-  # Chained to nvchecker rather than a clock: scheduled runs here start hours after their
-  # cron, so a fixed offset cannot keep autobump behind the issues it reads. A human still
-  # merges every PR; not-opted-in packages are skipped and non-mechanical bumps only comment.
+  # chained to nvchecker rather than a clock: scheduled runs here start hours after their
+  # cron, so a fixed offset cannot keep autobump behind the issues it reads
   workflow_run:
     workflows: [nvchecker]
     types: [completed]
@@ -74,15 +68,12 @@ jobs:
         echo "nvchecker concluded ${{ github.event.workflow_run.conclusion }}; nothing to bump" >&2
         exit 1
 
-    # nvchecker files the issues inside its own run, so they exist by the time this fires.
-    # The wait is for the search index the queue is read through, which can trail a new
-    # issue by a few minutes.
+    # the issues exist by now; this waits on the search index the queue is read through
     - name: wait for the issues to settle
       if: github.event_name == 'workflow_run'
       run: sleep 300
 
-  # After plan, so a run with an empty queue builds nothing; the 13 minutes this adds
-  # ahead of the workers are nothing against a run that bumps for hours.
+  # after plan, so a run with an empty queue builds nothing
   env:
     needs: plan
     if: ${{ fromJSON(needs.plan.outputs.plan).matrix.include[0] != null }}
@@ -94,8 +85,7 @@ jobs:
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_env }}
       date: ${{ inputs.env_date || '' }}
 
-  # plan and collect need python3 and gh, both on the runner image; only the bump workers
-  # need portage, and a container start costs a 3.5 GB pull.
+  # only the workers need portage, and a container start costs a 3.5 GB pull
   plan:
     needs: wait
     runs-on: ubuntu-latest
@@ -140,8 +130,7 @@ jobs:
 
   bump:
     needs: [env, plan]
-    # listed in full because a job-level block replaces the workflow defaults; packages:read
-    # is what pulls the environment image
+    # a job-level block replaces the workflow defaults, so all four are listed
     permissions:
       contents: write
       pull-requests: write
@@ -149,10 +138,8 @@ jobs:
       packages: read
     if: ${{ fromJSON(needs.plan.outputs.plan).matrix.include[0] != null }}
     runs-on: ubuntu-latest
-    # Eight shards run at once: a worker's fixed cost is the image pull plus a 37s webrsync,
-    # and it is paid in parallel, so it costs runner minutes rather than wall clock. What the
-    # queue actually waits on is one slow package holding its shard, and that only gets
-    # shorter with more shards.
+    # a worker's fixed cost is paid in parallel, so more shards only shorten the tail one
+    # slow package leaves behind
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -173,18 +160,15 @@ jobs:
     - name: sync gentoo main tree
       run: emerge-webrsync --no-pgp-verify
 
-    # MAKEOPTS and CPU_FLAGS_X86 are the only config the image cannot carry: they describe
-    # the runner. Without the flags, REQUIRED_USE=cpu_flags_x86_avx2 never resolves and the
-    # bump reports a build failure. Derive them from the runner, do not pin a list.
+    # both describe the runner, so the image cannot carry them; without the flags a
+    # cpu_flags_x86 REQUIRED_USE reads as a build failure
     - name: tune portage for this runner
       run: |
         echo "MAKEOPTS=\"\${MAKEOPTS} -j$(nproc)\"" >> /etc/portage/make.conf
         echo "*/* $(cpuid2cpuflags)" > /etc/portage/package.use/autobump-cpuflags
 
-    # binpkgs the engine's build tests produced (FEATURES=buildpkg), so a heavy dep is built
-    # once and unpacked afterwards. Every shard restores; only one saves, because a cache
-    # entry holds the whole directory and eight near-copies a day would evict everything
-    # else in the 10 GB the repo gets.
+    # every shard restores, one saves: an entry holds the whole directory, and eight
+    # near-copies a day would evict the rest of the repo's 10 GB
     - name: restore dependency binpkgs
       uses: actions/cache/restore@v6
       with:


### PR DESCRIPTION
三个改动：

- `docker/login-action` v3→v4，`docker/build-push-action` v6→v7，两者的新主版本以 Node 24 为目标，runner 每轮打印的弃用警告随之消失。`actions/delete-package-versions` 最新仍是 2024 年的 v5，没有对应版本；为消一条警告手写删除包版本的逻辑，风险是删错镜像，因此保留。
- 镜像查找不再丢弃 stderr。原本写成 `> /dev/null 2>&1`，镜像不存在和登录失败在日志里无法区分。
- 三个文件的注释按 AGENTS.md 收敛：删掉复述步骤本身的段落，只留代码表达不出的原因，每处一到两行。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
