### PR TITLE
autobump: retry issues the ledger already recorded

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -41,6 +41,10 @@ on:
         description: 'max issues per run (0 = the whole queue)'
         required: false
         default: '0'
+      retry:
+        description: 'run the named issues again even if they are already recorded'
+        type: boolean
+        default: false
       rebuild_env:
         description: 'rebuild the worker environment image'
         type: boolean
@@ -121,13 +125,14 @@ jobs:
         XDG_STATE_HOME: ${{ github.workspace }}/.autobump-state
         ISSUES: ${{ github.event.inputs.issues }}
         LIMIT: ${{ github.event.inputs.limit || 0 }}
+        RETRY: ${{ github.event.inputs.retry == 'true' && '--retry' || '' }}
         SHARDS: '8'
       run: |
         # validate before use: ISSUES is space-separated issue numbers, LIMIT and SHARDS are ints.
         case "$ISSUES" in *[!0-9\ ]*) echo "issues must be numbers: $ISSUES" >&2; exit 1;; esac
         case "$LIMIT" in ''|*[!0-9]*) echo "limit must be a number: $LIMIT" >&2; exit 1;; esac
         # $ISSUES intentionally unquoted so it word-splits into positional args (validated above).
-        plan=$(python3 scripts/autobump-sweep.py $ISSUES --limit "$LIMIT" --plan "$SHARDS")
+        plan=$(python3 scripts/autobump-sweep.py $ISSUES $RETRY --limit "$LIMIT" --plan "$SHARDS")
         echo "plan=$plan" >> "$GITHUB_OUTPUT"
 
   bump:

--- a/scripts/autobump-sweep.py
+++ b/scripts/autobump-sweep.py
@@ -33,6 +33,7 @@ class Arguments:
     comment: bool
     limit: str
     issues: list[str]
+    retry: bool
     plan_shards: int | None
     worker: str | None
     delta: str | None
@@ -51,6 +52,7 @@ class Settings:
     comment: bool
     limit: str
     issues: list[str]
+    retry: bool
     engine: str | None
     plan_shards: int | None
     worker_items: list[dict] | None
@@ -150,6 +152,7 @@ def parse_args(argv):
         "comment": False,
         "limit": "0",
         "issues": [],
+        "retry": False,
         "plan_shards": None,
         "worker": None,
         "delta": None,
@@ -163,6 +166,8 @@ def parse_args(argv):
             parsed["pr"] = "--pr"
         elif arg == "--comment":
             parsed["comment"] = True
+        elif arg == "--retry":
+            parsed["retry"] = True
         elif arg in VALUE_FLAGS:
             option = VALUE_FLAGS[arg]
             if remaining:
@@ -519,6 +524,7 @@ def read_settings(argv):
         comment=arguments.comment,
         limit=arguments.limit,
         issues=arguments.issues,
+        retry=arguments.retry,
         engine=os.environ.get("AUTOBUMP_ENGINE"),
         plan_shards=arguments.plan_shards,
         worker_items=worker_items,
@@ -606,6 +612,15 @@ def engine_arguments(tools, package):
     return args, f"— `autobump` enabled{footer}", None
 
 
+# An engine fix does not reach a package the ledger already recorded, and DONE is keyed by
+# version, so a deferred bump would wait for the next release. --retry runs the named issues
+# again; it needs their numbers, so a re-run cannot sweep the whole queue by accident.
+def ledger_skip(settings, package, version):
+    if settings.retry and settings.issues:
+        return None
+    return matching_ledger_line(settings.done_ledger, package, version)
+
+
 def plan_issues(settings, issues, apply_run_limit):
     results = {}
     items = []
@@ -617,7 +632,7 @@ def plan_issues(settings, issues, apply_run_limit):
             results[issue] = result
             continue
 
-        prior = matching_ledger_line(settings.done_ledger, package, version)
+        prior = ledger_skip(settings, package, version)
         if prior is not None:
             results[issue] = f"skip ({prior})"
             continue
@@ -897,7 +912,7 @@ def run_issues(settings, issues, apply_run_limit, tools, engine):
         if result:
             results[issue] = result
             continue
-        prior = matching_ledger_line(settings.done_ledger, package, version)
+        prior = ledger_skip(settings, package, version)
         if prior is not None:
             results[issue] = f"skip ({prior})"
             continue


### PR DESCRIPTION
escalate 会把这次 bump 记进 `done.list`，而 ledger 的 key 是包加版本，所以引擎修好之后，已经记过的包要等上游发下一个版本才会再跑一次。这两天修的 payload 规则就卡在这：cursor 3.19.13、rebased-bin 1.1.15、claude-desktop 1.46388.2 都已经被记下了。

`--retry` 让指名的 issue 重跑一次，忽略 ledger。必须同时给 issue 号，光给 `--retry` 不指名照旧按 ledger 跳过，免得手滑重扫整个队列。工作流加一个 `retry` 勾选框，勾了才传这个参数。

测试在 gentoo-zh/autobump-rb（overlay 不放测试），`test/sweep/test_autobump_sweep.py` 两条：指名 issue 加 `--retry` 会真的跑引擎、只给 `--retry` 不指名照样跳过。两个变异都会让测试红：`--retry` 不看有没有指名、`--retry` 完全没作用。
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
