### PR TITLE
net-proxy/honk: new package, add 9999

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2294,6 +2294,9 @@ prefix = "v"
 github_account = ["yangmame", "peeweep"]
 autobump = true
 
+# live package only
+#["net-proxy/honk"]
+
 ["net-proxy/hysteria"]
 source = "github"
 github = "HyNetworks/hysteria"

--- a/net-proxy/honk/files/honk.confd
+++ b/net-proxy/honk/files/honk.confd
@@ -1,0 +1,11 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Config file used by honk.
+HONK_CONFIG="/etc/honk/config.dae"
+
+# Command args used by honk.
+HONK_ARGS="--config ${HONK_CONFIG}"
+
+# One file descriptor per tracked connection.
+rc_ulimit="-u 512 -n 1048576"

--- a/net-proxy/honk/files/honk.initd
+++ b/net-proxy/honk/files/honk.initd
@@ -1,0 +1,56 @@
+#!/sbin/openrc-run
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+: "${HONK_CONFIG:=/etc/honk/config.dae}"
+: "${HONK_ARGS:=--config ${HONK_CONFIG}}"
+
+description="honk transparent proxy engine"
+pidfile="/run/${RC_SVCNAME}.pid"
+command="/usr/bin/honk-core"
+command_args="${HONK_ARGS}"
+command_background="yes"
+extra_started_commands="reload"
+
+output_log="/var/log/honk.log"
+error_log="/var/log/honk.log"
+
+depend() {
+	after docker net net-online sysctl local
+	use net
+}
+
+start_pre() {
+	if [ -d /sys/fs/bpf ]; then
+		if ! mountinfo -q /sys/fs/bpf; then
+			mount -t bpf bpffs /sys/fs/bpf
+		fi
+	else
+		eerror "bpf filesystem not mounted, exiting..."
+		return 1
+	fi
+
+	if [ -d /sys/fs/cgroup ] && ! mountinfo -q /sys/fs/cgroup/; then
+		eerror "cgroup filesystem not mounted, exiting..."
+		return 1
+	fi
+
+	# the engine holds this flock and owns fixed kernel-side names, so refuse
+	# early rather than race a second instance for them
+	if [ -e /run/honk-core.lock ] && ! flock -n /run/honk-core.lock true; then
+		eerror "another honk-core instance holds /run/honk-core.lock, exiting..."
+		return 1
+	fi
+
+	if [ ! -f "${HONK_CONFIG}" ]; then
+		ewarn "${HONK_CONFIG} does not exist."
+	fi
+
+	checkpath -f -m 0644 "$output_log"
+}
+
+reload() {
+	ebegin "Reloading ${RC_SVCNAME}"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	eend $?
+}

--- a/net-proxy/honk/files/honk.service
+++ b/net-proxy/honk/files/honk.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=honk transparent proxy engine
+Documentation=https://github.com/daeuniverse/honk
+After=network-online.target systemd-sysctl.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/honk-core --config /etc/honk/config.dae
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-abnormal
+LimitNPROC=512
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/net-proxy/honk/honk-9999.ebuild
+++ b/net-proxy/honk/honk-9999.ebuild
@@ -1,0 +1,136 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+CRATES=""
+RUST_MIN_VER="1.85.0"
+# same requirement as dev-util/bpf-linker
+RUST_REQ_USE="llvm_targets_BPF(+),rust_sysroots_bpf(-)"
+
+inherit cargo git-r3 linux-info systemd
+
+DESCRIPTION="Rust eBPF transparent proxy engine with a dae datapath and sing-box outbounds"
+HOMEPAGE="https://github.com/daeuniverse/honk"
+EGIT_REPO_URI="https://github.com/daeuniverse/honk.git"
+
+LICENSE="GPL-3"
+# Dependent crate licenses
+LICENSE+="
+	0BSD Apache-2.0 BSD-2 BSD CC0-1.0 ISC MIT MPL-2.0 openssl
+	Unicode-3.0 Unlicense ZLIB
+"
+SLOT="0"
+
+BDEPEND="
+	dev-build/cmake
+	llvm-core/clang
+	virtual/pkgconfig
+	>=dev-util/bpf-linker-0.11.0
+"
+RDEPEND="
+	app-alternatives/v2ray-geoip
+	app-alternatives/v2ray-geosite
+"
+
+MINKV="5.8"
+
+pkg_setup() {
+	# linux-info exports pkg_setup too, so call rust's explicitly
+	linux-info_pkg_setup
+	rust_pkg_setup
+}
+
+pkg_pretend() {
+	local CONFIG_CHECK="~BPF ~BPF_SYSCALL ~BPF_JIT ~CGROUP_BPF ~NET_CLS_BPF
+		~NET_SCH_INGRESS ~NET_CLS_ACT ~NET_NS
+		~NF_TABLES ~NF_TABLES_INET ~NETFILTER_NETLINK_QUEUE"
+
+	if kernel_is -lt ${MINKV//./ }; then
+		ewarn "Kernel version at least ${MINKV} required"
+	fi
+
+	check_extra_config
+}
+
+src_unpack() {
+	git-r3_src_unpack
+	cargo_live_src_unpack
+
+	# honk-ebpf is outside the workspace with its own lock, and --sync adds its
+	# crates to the vendor directory rather than replacing it
+	local -x CARGO_HOME="${ECARGO_REGISTRY_DIR}"
+	addwrite "${CARGO_HOME}"
+
+	cd "${S}" || die
+	"${CARGO}" vendor --sync crates/honk-ebpf/Cargo.toml "${ECARGO_VENDOR}" \
+		|| die "failed to vendor the eBPF crate's dependencies"
+}
+
+src_configure() {
+	local myfeatures=(
+		ebpf
+	)
+
+	cargo_src_configure
+}
+
+src_compile() {
+	# build.rs builds this itself through rustup, which we do not have
+	# aya-ebpf needs #![feature(asm_experimental_arch)]
+	local -x RUSTC_BOOTSTRAP=1
+	# any value here, empty included, drops the crate's own target rustflags
+	# carrying -C linker=bpf-linker and the --btf link argument
+	unset RUSTFLAGS
+
+	local cmd=(
+		"${CARGO}" build
+		--release
+		--offline
+		--target=bpfel-unknown-none
+	)
+
+	pushd crates/honk-ebpf >/dev/null || die
+	echo "${cmd[*]}" >&2
+	"${cmd[@]}" || die "${cmd[*]} failed"
+	# aya rejects an object without it, and losing the flags above is silent
+	readelf -S target/bpfel-unknown-none/release/honk-ebpf | grep -q '\.BTF' \
+		|| die "eBPF object has no .BTF section"
+	popd >/dev/null || die
+
+	cargo_src_compile -p honk-core -p honk-tool
+}
+
+src_install() {
+	# cargo install takes neither a virtual manifest nor -p
+	dobin "$(cargo_target_dir)"/honk-core
+	dobin "$(cargo_target_dir)"/honk-tool
+
+	newinitd "${FILESDIR}"/honk.initd honk
+	newconfd "${FILESDIR}"/honk.confd honk
+	systemd_newunit "${FILESDIR}"/honk.service honk.service
+
+	keepdir /etc/honk
+	insinto /usr/share/honk
+	newins example.dae config.dae.example
+	doins config.min.dae
+
+	dodoc README.md README_CN.md
+	docinto doc
+	dodoc -r doc/en doc/zh
+
+	# honk-config's DEFAULT_DATA_DIR, and the only asset path find_dat() searches
+	# that we control
+	keepdir /var/share/honk
+	dosym -r /usr/share/v2ray/geoip.dat /var/share/honk/geoip.dat
+	dosym -r /usr/share/v2ray/geosite.dat /var/share/honk/geosite.dat
+}
+
+pkg_postinst() {
+	elog "honk needs a configuration at /etc/honk/config.dae before it will start."
+	elog "An annotated example is installed as /usr/share/honk/config.dae.example."
+	elog
+	elog "The engine runs as root: it loads eBPF programs, creates the dae0/daens"
+	elog "pair, and owns nftables table 'inet honk_nfqueue' and netlink queue 320."
+	elog "A firewall manager in the same network namespace must leave those alone."
+}

--- a/net-proxy/honk/metadata.xml
+++ b/net-proxy/honk/metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>zakk@gentoozh.org</email>
+		<name>Zakk</name>
+	</maintainer>
+	<longdescription lang="en">
+		honk is a Linux transparent proxy engine written in Rust. Its kernel path follows
+		dae's TC and match_set model with a dae0/daens pair, while its userspace outbound
+		groups, multi-protocol dialers and Clash-compatible API follow sing-box-oriented
+		designs. It is not a port of either project. Upstream describes the current state
+		as experimental and advises against production use.
+	</longdescription>
+	<upstream>
+		<remote-id type="github">daeuniverse/honk</remote-id>
+		<bugs-to>https://github.com/daeuniverse/honk/issues</bugs-to>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
因为上游至今只发到 v0.0.1.beta.72、README 自述为 experimental 且不建议用于生产，
而这个引擎以 root 接管数据面，所以先只收 live ebuild，等上游发出稳定标签再加版本
化 ebuild。


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
