### PR TITLE
dev-util/codex: block dev-util/codex-bin

### DIFF
--- a/dev-util/codex/codex-0.153.4-r1.ebuild
+++ b/dev-util/codex/codex-0.153.4-r1.ebuild
@@ -80,7 +80,9 @@ DEPEND="
 	dev-libs/openssl:=
 	sys-apps/dbus
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	!dev-util/codex-bin
+"
 BDEPEND="virtual/pkgconfig"
 
 # rust does not use *FLAGS from make.conf, silence portage warning


### PR DESCRIPTION
因为两者都装 /usr/bin/codex 与 /usr/bin/codex-code-mode-host，共存会撞文件，所以补上与 dev-util/codex-bin 已有的那条对称的阻挡。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
