### PR TITLE
app-misc/chatgpt-desktop: note the pet needs XWayland

### DIFF
--- a/app-misc/chatgpt-desktop/chatgpt-desktop-26.901.51231.ebuild
+++ b/app-misc/chatgpt-desktop/chatgpt-desktop-26.901.51231.ebuild
@@ -120,4 +120,9 @@ pkg_postinst() {
 
 	optfeature "Git repository support" dev-vcs/git
 	optfeature "secret/keyring storage" virtual/secret-service
+
+	use wayland || return 0
+
+	elog "The desktop pet does not work under Wayland."
+	elog "Run 'chatgpt --ozone-platform=x11' to use it."
 }


### PR DESCRIPTION
pet 用 `setBounds` 指定螢幕座標並置頂,Wayland 不給客戶端做,所以開 `wayland` USE 後 pet 不顯示,加 elog 指回 x11。實測 x11 正常。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
