### PR TITLE
net-im/wechat: fix startup on systems without Wayland

### DIFF
--- a/net-im/wechat/files/bwrap.sh
+++ b/net-im/wechat/files/bwrap.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Set during ebuild configuration
+EBUILD_WAYLAND=false
+
 command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
@@ -126,6 +129,12 @@ read_bwrap_flags "${WECHAT_BWRAP_FLAGS_FILE}" bwrap_flags
 
 GCC_LIB_PATH="$(gcc_runtime_path)"
 
+if "${EBUILD_WAYLAND}" && [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+    QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-wayland;xcb}"
+else
+    QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"
+fi
+
 require_path /etc/localtime
 require_path /etc/machine-id
 require_path /etc/resolv.conf
@@ -189,7 +198,7 @@ declare -a bwrap_cmd=(
     --setenv XDG_STATE_HOME "${WECHAT_STATE_HOME}"
     --setenv XDG_DOWNLOAD_DIR "${WECHAT_DOWNLOAD_DIR}"
     --setenv QT_AUTO_SCREEN_SCALE_FACTOR 1
-    --setenv QT_QPA_PLATFORM "${QT_QPA_PLATFORM:-wayland;xcb}"
+    --setenv QT_QPA_PLATFORM "${QT_QPA_PLATFORM}"
     --setenv GTK_USE_PORTAL 1
 )
 

--- a/net-im/wechat/files/wechat.sh
+++ b/net-im/wechat/files/wechat.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Set during ebuild configuration
+EBUILD_WAYLAND=false
+
 gcc_runtime_path() {
     if command -v gcc-config >/dev/null 2>&1; then
         gcc-config --get-lib-path 2>/dev/null || true
@@ -20,7 +23,11 @@ if [[ -f "${XDG_CONFIG_HOME}/wechat-flags.conf" ]]; then
 fi
 
 export QT_AUTO_SCREEN_SCALE_FACTOR=1
-export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-wayland;xcb}"
+if "${EBUILD_WAYLAND}" && [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+    export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-wayland;xcb}"
+else
+    export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"
+fi
 
 gcc_lib_path="$(gcc_runtime_path)"
 if [[ -n "${gcc_lib_path}" ]]; then

--- a/net-im/wechat/wechat-4.1.13.9-r1.ebuild
+++ b/net-im/wechat/wechat-4.1.13.9-r1.ebuild
@@ -18,7 +18,7 @@ LICENSE="all-rights-reserved"
 
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm64 ~loong"
-IUSE="bwrap"
+IUSE="bwrap wayland"
 
 RESTRICT="strip mirror bindist"
 BDEPEND="
@@ -29,6 +29,7 @@ RDEPEND="
 	app-arch/bzip2
 	app-crypt/mit-krb5
 	dev-libs/nss
+	dev-libs/wayland
 	media-libs/libpulse
 	media-libs/mesa
 	net-print/cups
@@ -74,20 +75,23 @@ src_install() {
 	dodir /opt/wechat
 	cp -r opt/wechat/. "${D}/opt/wechat/" || die
 
+	local launcher=wechat.sh
 	if use bwrap; then
-		newbin "${FILESDIR}/bwrap.sh" wechat
+		launcher=bwrap.sh
 		exeinto /opt/wechat
 		doexe "${FILESDIR}/xdg-open.sh"
-	else
-		newbin "${FILESDIR}/wechat.sh" wechat
 	fi
 
-	local exec_envs=( "QT_AUTO_SCREEN_SCALE_FACTOR=1" "\"QT_QPA_PLATFORM=wayland;xcb\"" )
+	cp "${FILESDIR}/${launcher}" "${T}" || die
+	if use wayland; then
+		sed -i -e "/^EBUILD_WAYLAND=/s/false/true/" "${T}/${launcher}" || die
+	fi
+	newbin "${T}/${launcher}" wechat
 
 	sed -i \
 		-e "s|^Icon=.*|Icon=wechat|" \
 		-e "s|^Categories=.*|Categories=Network;InstantMessaging;Chat;|" \
-		-e "s|^Exec=.*|Exec=env ${exec_envs[*]} /usr/bin/wechat %U|" \
+		-e "s|^Exec=.*|Exec=/usr/bin/wechat %U|" \
 		usr/share/applications/wechat.desktop || die
 	domenu usr/share/applications/wechat.desktop
 


### PR DESCRIPTION
上游的 Wayland stub 每次启动都 `dlopen` `libwayland-client.so.0`，只有平台明确是 `xcb` 时才把失败当作非致命。Closes #13152

1. 因为两个启动器把 `QT_QPA_PLATFORM` 写死成 `wayland;xcb`，纯 X 机器上直接 abort，所以改成只在 `WAYLAND_DISPLAY` 存在时才请求 wayland。
2. 因为需要让用户能整体关掉 wayland 支持，所以加 `IUSE="wayland"`，由 `src_install` 把启动器里的 `EBUILD_WAYLAND` 置为 `true`，与运行时判断串联。这两点的写法取自 `net-im/discord` 的 `files/launcher-r1.sh`。`wayland` 是全局 USE 描述，`metadata.xml` 不需要补。
3. 因为 `.desktop` 的 `Exec` 重复设置这两个变量会盖掉启动器的判断，所以改为 `Exec=/usr/bin/wechat %U`。
4. 因为程序运行时通过 `dlopen` 加载 `libwayland-client.so.0`，没有 DT_NEEDED、soname 检查看不到，所以 `RDEPEND` 增加 `dev-libs/wayland`。与 `net-im/discord` 一样不放进 `wayland? ( )`。

先确认这个 stub 绕不开，用 bwrap 把 libwayland 绑到 `/dev/null` 模拟纯 X 机器：

| `QT_QPA_PLATFORM` | 结果 |
| --- | --- |
| 不设（Qt 自动探测） | abort，`Wayland stub: initialization failed` |
| `wayland;xcb` | abort，即改动前的行为 |
| `xcb` | 启动正常 |

改动后四种 USE 组合各在 Wayland 会话和纯 X 环境下启动一次，全部正常；`-bwrap` 的两组在纯 X 环境下同时隐藏了 libwayland：

| USE | Wayland 会话 | 纯 X |
| --- | --- | --- |
| `wayland -bwrap` | 正常，原生 wayland | 正常 |
| `-wayland -bwrap` | 正常，走 xcb | 正常 |
| `wayland bwrap` | 正常 | 正常 |
| `-wayland bwrap` | 正常 | 正常 |

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
