### PR TITLE
sys-apps/pnpm: restrict tests

### DIFF
--- a/sys-apps/pnpm/pnpm-12.3.4.ebuild
+++ b/sys-apps/pnpm/pnpm-12.3.4.ebuild
@@ -27,6 +27,7 @@ LICENSE+="
 "
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
+RESTRICT="test"
 
 RDEPEND="net-libs/nodejs"
 


### PR DESCRIPTION
Closes #13206. Restrict tests: three dialoguer prompt tests block forever on non-interactive stdin and twelve audit/list/view tests compare terminal-formatted output.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
