### PR TITLE
media-plugins/osdlyrics: fix optfeature description wording

### DIFF
--- a/media-plugins/osdlyrics/osdlyrics-0.5.16.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-0.5.16.ebuild
@@ -73,6 +73,6 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 	if has_version media-sound/mpd; then
-		optfeature "to interface with MPD" dev-python/python-mpd2
+		optfeature "MPD backend support" dev-python/python-mpd2
 	fi
 }

--- a/media-plugins/osdlyrics/osdlyrics-9999.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-9999.ebuild
@@ -73,6 +73,6 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 	if has_version media-sound/mpd; then
-		optfeature "to interface with MPD" dev-python/python-mpd2
+		optfeature "MPD backend support" dev-python/python-mpd2
 	fi
 }


### PR DESCRIPTION
`optfeature.eclass` 在原子与描述之间自己插了 `for`（`msg="${msg:0: -4} for ${desc}"`），描述以不定式开头会渲染成

```
 dev-python/python-mpd2 for to interface with MPD
```

改成名词短语。0.5.16 与 9999 两个版本同改。仅 `pkg_postinst` 消息变化，按 AGENTS.md 不 revbump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
