### PR TITLE
media-video/mpv-handler: use optfeature for the downloader hint

### DIFF
--- a/media-video/mpv-handler/mpv-handler-0.4.2.ebuild
+++ b/media-video/mpv-handler/mpv-handler-0.4.2.ebuild
@@ -10,7 +10,7 @@ CRATES="
 
 RUST_MIN_VER="1.85.0"
 
-inherit cargo desktop xdg
+inherit cargo desktop optfeature xdg
 
 DESCRIPTION="Play website videos and songs with mpv & yt-dlp"
 HOMEPAGE="https://github.com/akiirui/mpv-handler"
@@ -40,6 +40,6 @@ src_install() {
 
 pkg_postinst() {
 	xdg_pkg_postinst
-	elog "install net-misc/youtube-dl (recommended) or net-misc/yt-dlp"
-	elog "to enable mpv to play video and music from the websites."
+
+	optfeature "playing video and music from websites" net-misc/yt-dlp
 }


### PR DESCRIPTION
这条 elog 本来就是「装了某个包才有的可选运行时功能」，正是 optfeature 的用途。

顺带修掉一个失效引用：elog 把 `net-misc/youtube-dl` 列为 recommended，而该包在 ::gentoo 与 ::gentoo-zh 都已不存在。

`pkg_postinst` 原有的 `xdg_pkg_postinst` 保留（`xdg.eclass` 用 `EXPORT_FUNCTIONS` 导出该阶段）。仅消息变化，不 revbump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
