### PR TITLE
app-shells/gitstatus: use optfeature for the Zsh theme hint

### DIFF
--- a/app-shells/gitstatus/gitstatus-1.5.5.ebuild
+++ b/app-shells/gitstatus/gitstatus-1.5.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake flag-o-matic
+inherit cmake flag-o-matic optfeature
 
 DESCRIPTION="Git status for Bash and Zsh prompt"
 HOMEPAGE="https://github.com/romkatv/gitstatus"
@@ -95,8 +95,8 @@ src_install() {
 }
 
 pkg_postinst() {
-	elog "The easiest way to take advantage of gitstatus from Zsh is to use a theme"
-	elog "that's already integrated with it. For example: app-shells/zsh-theme-powerlevel10k"
 	elog "The easiest way to take advantage of gitstatus from Bash is via gitstatus.prompt.sh."
 	elog "Follow this guide: https://github.com/romkatv/gitstatus#using-from-bash"
+
+	optfeature "a Zsh theme already integrated with gitstatus" app-shells/zsh-theme-powerlevel10k
 }


### PR DESCRIPTION
推荐安装 `app-shells/zsh-theme-powerlevel10k` 属于可选运行时功能，改用 optfeature；Bash 那半是使用说明，留在 elog。仅消息变化，不 revbump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
