### PR TITLE
app-misc/joshuto: use optfeature for the patched font hint

### DIFF
--- a/app-misc/joshuto/joshuto-0.9.9.ebuild
+++ b/app-misc/joshuto/joshuto-0.9.9.ebuild
@@ -8,7 +8,7 @@ EAPI=8
 CRATES="
 "
 
-inherit cargo
+inherit cargo optfeature
 
 DESCRIPTION="Terminal file manager inspired by ranger"
 HOMEPAGE="https://github.com/kamiyaa/joshuto"
@@ -51,10 +51,6 @@ src_compile() {
 }
 
 pkg_postinst() {
-	elog ""
-	elog "For proper devicons support, correct patched font is needed"
-	elog "For example:"
-	elog "https://github.com/ryanoasis/nerd-fonts"
-	elog "or media-fonts/nerd-fonts"
-	elog ""
+	optfeature "devicons support, which needs a patched font" \
+		media-fonts/nerd-fonts
 }


### PR DESCRIPTION
devicons 需要 `media-fonts/nerd-fonts`，属于可选运行时功能。仅 `pkg_postinst` 消息变化，按 AGENTS.md 不 revbump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
