### PR TITLE
app-shells/zsh-theme-powerlevel10k: use optfeature for the font hint

### DIFF
--- a/app-shells/zsh-theme-powerlevel10k/zsh-theme-powerlevel10k-1.20.0.ebuild
+++ b/app-shells/zsh-theme-powerlevel10k/zsh-theme-powerlevel10k-1.20.0.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=8
 
+inherit optfeature
+
 MY_PN="${PN##zsh-theme-}"
 
 DESCRIPTION="Theme for Zsh that emphasizes speed, flexibility and out-of-the-box experience"
@@ -45,5 +47,6 @@ src_install() {
 
 pkg_postinst() {
 	elog "To use this theme, source /usr/share/zsh/site-functions/powerlevel10k/powerlevel10k.zsh-theme in your ~/.zshrc"
-	elog "The full choice of style options is available only when using Nerd Fonts. For example: media-fonts/nerd-fonts"
+
+	optfeature "the full choice of style options" media-fonts/nerd-fonts
 }


### PR DESCRIPTION
完整样式选项需要 `media-fonts/nerd-fonts`，属于可选运行时功能；如何 source 主题那句是使用说明，留在 elog。仅 `pkg_postinst` 消息变化，按 AGENTS.md 不 revbump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
