### PR TITLE
app-shells/gitstatus: only advise a Zsh theme when zsh-completion is on

### DIFF
--- a/app-shells/gitstatus/gitstatus-1.5.5.ebuild
+++ b/app-shells/gitstatus/gitstatus-1.5.5.ebuild
@@ -95,8 +95,10 @@ src_install() {
 }
 
 pkg_postinst() {
-	elog "The easiest way to take advantage of gitstatus from Zsh is to use a theme"
-	elog "that's already integrated with it. For example: app-shells/zsh-theme-powerlevel10k"
+	if use zsh-completion; then
+		elog "The easiest way to take advantage of gitstatus from Zsh is to use a theme"
+		elog "that's already integrated with it. For example: app-shells/zsh-theme-powerlevel10k"
+	fi
 	elog "The easiest way to take advantage of gitstatus from Bash is via gitstatus.prompt.sh."
 	elog "Follow this guide: https://github.com/romkatv/gitstatus#using-from-bash"
 }


### PR DESCRIPTION
`gitstatus.*.zsh` 只在 `zsh-completion` 开启时安装（`src_install` 里的
`if use zsh-completion`），关闭时用户根本没有 Zsh 入口，却照样会被建议去装
Zsh 主题。把这两行挂到该 USE 上，消息文本一字未改。

**不改用 optfeature**，理由三条：

- `app-shells/zsh-theme-powerlevel10k` 多数人是 git clone 或经 plugin manager
  （zinit / oh-my-zsh 等）安装，`has_version` 看不到，会对真正在用它的人一直提示。
- 原文的「For example」表示这只是其中一种已集成的主题，optfeature 的
  `<atom> for <desc>` 格式表达不了这层语气。
- ::gentoo 里用 optfeature 推荐 `app-shells/*` 的只有 2 处
  （`dev-debug/ddd` → `app-shells/bashdb`），先例不足；字型那类有 42 处是另一回事。

仅 `pkg_postinst` 消息条件变化，按 AGENTS.md 不 revbump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
