### PR TITLE
dev-util/pi-coding-agent-xz: new package, add 9999

### DIFF
--- a/dev-util/pi-coding-agent-xz/metadata.xml
+++ b/dev-util/pi-coding-agent-xz/metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>xiangzhedev@gmail.com</email>
+		<name>xz-dev</name>
+	</maintainer>
+	<use>
+		<flag name="coexist">Install the launcher as /opt/bin/pi-xz instead of /opt/bin/pi, allowing installation alongside dev-util/pi-coding-agent-bin</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">xz-dev/pi</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/dev-util/pi-coding-agent-xz/pi-coding-agent-xz-9999.ebuild
+++ b/dev-util/pi-coding-agent-xz/pi-coding-agent-xz-9999.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit git-r3
+
+DESCRIPTION="A terminal-based coding agent with multi-model support (xz-dev downstream fork)"
+HOMEPAGE="https://github.com/xz-dev/pi"
+EGIT_REPO_URI="https://github.com/xz-dev/pi.git"
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="X coexist"
+RESTRICT="strip"
+
+BDEPEND="
+	~dev-lang/bun-bin-1.4.2
+	>=net-libs/nodejs-22.19
+"
+RDEPEND="
+	!coexist? ( !dev-util/pi-coding-agent-bin )
+	sys-apps/fd
+	sys-apps/ripgrep
+	X? ( x11-libs/libxcb )
+"
+
+src_unpack() {
+	git-r3_src_unpack
+
+	# npm and the models.dev fetch need network, which only src_unpack has.
+	cd "${S}" || die
+	npm ci --ignore-scripts || die
+	npm run hydrate:model-data || die
+}
+
+src_compile() {
+	local arch=$(usex amd64 x64 arm64)
+
+	# Same steps as scripts/build-binaries.sh minus the zip packaging.
+	NODE_ENV=production npm run build:offline || die
+
+	cd "${S}/packages/coding-agent" || die
+	bun build --compile --minify --bytecode --format=esm \
+		--target="bun-linux-${arch}" \
+		./dist/bun/cli.js ./src/utils/image-resize-worker.ts \
+		--outfile dist/pi || die
+	npm run copy-binary-assets || die
+
+	# copy-binary-assets leaves the X11 clipboard helper to build-binaries.sh.
+	if use X; then
+		mkdir -p "dist/native/linux/prebuilds/linux-${arch}" || die
+		cp "../tui/native/linux/prebuilds/linux-${arch}/linux-platform-x11.node" \
+			"dist/native/linux/prebuilds/linux-${arch}/" || die
+		cp ../../LICENSE dist/native/LICENSE || die
+	fi
+
+	mv dist/pi dist/pi-native || die
+	cat > dist/pi <<-EOF || die
+		#!/bin/sh
+		exec "\$(dirname "\$(readlink -f "\$0")")/pi-native" "\$@"
+	EOF
+}
+
+src_install() {
+	local dist="${S}/packages/coding-agent/dist"
+	insinto /opt/${PN}
+	doins "${dist}"/{package.json,README.md,CHANGELOG.md,photon_rs_bg.wasm}
+	doins -r "${dist}"/{theme,assets,export-html,docs,examples}
+	use X && doins -r "${dist}"/native
+
+	# pi update --self refuses to overwrite the binary when this marker exists.
+	touch "${ED}/opt/${PN}/.portage.managed.lock" || die
+
+	exeinto /opt/${PN}
+	doexe "${dist}"/{pi,pi-native}
+
+	dosym ../${PN}/pi /opt/bin/$(usex coexist pi-xz pi)
+}


### PR DESCRIPTION
追踪 xz-dev/pi 下游分支 main 的 live 包。构建复刻上游 release CI（`bun build --compile --minify --bytecode`，`NODE_ENV=production`，钉 bun 1.4.2）；模型数据 hydrate 放在 `src_unpack` 联网窗口，`src_compile` 走 `build:offline` 适配 network sandbox。安装 `/opt/pi-coding-agent-xz/.portage.managed.lock`，因为 xz-dev/pi 的 `pi update --self` 检测到 `*.<channel>.managed.lock` 会拒绝自我替换并提示用渠道升级，所以 self-update 不会污染 portage 管理的 `/opt`。与 `dev-util/pi-coding-agent-bin` 通过 `USE=coexist` 互斥或并存（`pi-xz`）。依赖 `~dev-lang/bun-bin-1.4.2`，需要 gentoo-zh/overlay#13265（已合并）。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.