### PR TITLE
sys-kernel/mkinitcpio: resolve encrypt hook libraries at image build time

### DIFF
--- a/sys-kernel/mkinitcpio/files/mkinitcpio-42-encrypt-gentoo-paths.patch
+++ b/sys-kernel/mkinitcpio/files/mkinitcpio-42-encrypt-gentoo-paths.patch
@@ -1,0 +1,23 @@
+install/encrypt: resolve libgcc_s and the OpenSSL modules dir at build time
+
+Gentoo keeps libgcc_s.so.1 under the active gcc's libdir (or in
+/usr/lib64 from sys-libs/libgcc on clang systems) and the OpenSSL
+providers under /usr/$(get_libdir)/ossl-modules, so the /usr/lib paths
+hardcoded here are never found. Ask the dynamic loader cache and openssl
+itself instead, which also follows toolchain and libdir changes.
+
+--- a/install/encrypt
++++ b/install/encrypt
+@@ -20,10 +20,10 @@ build() {
+         '95-dm-notify.rules'
+ 
+     # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
+-    add_binary '/usr/lib/libgcc_s.so.1'
++    add_binary "$(ldconfig -p | awk '/[[:space:]]libgcc_s\.so\.1 \(/ { print $NF; exit }')" /usr/lib/libgcc_s.so.1
+ 
+     # cryptsetup loads the legacy provider which is required for whirlpool
+-    add_binary '/usr/lib/ossl-modules/legacy.so'
++    add_binary "$(openssl version -m | sed 's/.*"\(.*\)"/\1/')/legacy.so"
+ 
+     add_runscript
+ }

--- a/sys-kernel/mkinitcpio/mkinitcpio-42-r2.ebuild
+++ b/sys-kernel/mkinitcpio/mkinitcpio-42-r2.ebuild
@@ -46,18 +46,16 @@ BDEPEND="
 
 QA_PREBUILT="/usr/lib/initcpio/busybox"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-42-encrypt-gentoo-paths.patch
+)
+
 src_prepare() {
 	default
 	# tools/dist.sh reads the version from git describe, which the tarball lacks
 	sed -i "s|run_command('tools/dist.sh', 'get-version', check: true).stdout().strip()|'${PV}'|" \
 		meson.build || die
 	sed -i "s:/usr/lib/libkmod.so.2:/usr/$(get_libdir)/libkmod.so.2:" install/udev || die
-	# libgcc_s lives under the active gcc's libdir, resolve it when the image is built
-	local libgcc='add_binary "$(gcc-config -L | cut -d: -f1)/libgcc_s.so.1" /usr/lib/libgcc_s.so.1'
-	sed -i \
-		-e "/add_binary.*libgcc_s\.so\.1/s#.*#    ${libgcc}#" \
-		-e "s:/usr/lib/ossl-modules/legacy.so:/usr/$(get_libdir)/ossl-modules/legacy.so:" \
-		install/encrypt || die
 }
 
 src_configure() {


### PR DESCRIPTION
因为 42-r1 用 `gcc-config -L` 找 `libgcc_s.so.1`，只装 `sys-libs/libgcc` 的 clang 系统上没有这个路径，所以改在生成 image 时问 `ldconfig -p`；`legacy.so` 改问 `openssl version -m` 的 `MODULESDIR`，不再按 libdir 猜。两处做成 `files/` 里的 patch，去掉 42-r1 那段多层引号的 sed，与原来的 hwdb patch 同款。

因为改动只有开机才能验证，所以在 openrc + LUKS + btrfs 子卷的 VM 上用这个 ebuild 生成 image 实际开机通过，image 里的 `libgcc_s.so.1` 和 `legacy.so` 与系统文件逐字节相同。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
