### PR TITLE
.github/workflows: check commit messages with pkgcheck and PR text with pr-lint

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -97,6 +97,15 @@ jobs:
         git checkout --quiet "${head}"
 
         python3 scripts/pkgcheck-new-findings.py base-report.txt report.txt > new.txt
+
+        # commit messages (summary prefix and length, sign-off identity, tags) only
+        # run with --commits, which compares the checked-out branch to origin/HEAD
+        git remote set-head origin master
+        git checkout --quiet 'HEAD^2'
+        pkgcheck scan --commits --checks=GitCommitMessageCheck,GitPkgCommitsCheck \
+          > commits.txt 2>&1 || true
+        git checkout --quiet "${head}"
+        grep -v '^WARNING' commits.txt >> new.txt || true
         echo '--- new ---'; cat new.txt
         echo '--- all ---'; cat report.txt
 

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,25 @@
+name: PR lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Check pull request metadata
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: python3 scripts/pr-lint.py --title "$PR_TITLE" --body "$PR_BODY" --range "$BASE_SHA..$HEAD_SHA"

--- a/scripts/pr-lint.py
+++ b/scripts/pr-lint.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Check deterministic pull-request rules for gentoo-zh/overlay."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+CHECK_IDS = (
+    "title-format",
+    "routine-bump-body",
+    "no-ai-attribution",
+    "closes-format",
+    "new-package-nvchecker",
+    "overlay-toml-sorted",
+    "workflow-change",
+    "checklist",
+)
+
+PACKAGE_FILE_RE = re.compile(r"^[^/]+/[^/]+/[^/]+$")
+TABLE_RE = re.compile(r'^#?\["([^"]+)"\]$', re.MULTILINE)
+TEMPLATE_RE = re.compile(r"^---\s*$", re.MULTILINE)
+AI_ATTRIBUTION_RE = re.compile(
+    r"Co-Authored-By:\s*.*(?:Claude|Copilot|Codex|GPT|ChatGPT|Gemini)|"
+    r"Generated with|Claude-Session:|🤖",
+    re.IGNORECASE,
+)
+NOREPLY_SIGNOFF_RE = re.compile(
+    r"^Signed-off-by:.*@users\.noreply\.github\.com\b", re.IGNORECASE
+)
+OVERLAY_ISSUE_URL = "https://github.com/gentoo-zh/overlay/issues/"
+OVERLAY_TOML = ".github/workflows/overlay.toml"
+
+
+@dataclass(frozen=True)
+class Change:
+    status: str
+    old_path: str | None
+    new_path: str
+
+    @property
+    def paths(self) -> tuple[str, ...]:
+        return tuple(path for path in (self.old_path, self.new_path) if path is not None)
+
+
+@dataclass(frozen=True)
+class Inputs:
+    title: str
+    body: str
+    changes: tuple[Change, ...]
+    commits: str
+    overlay_toml: str | None
+    base_overlay_toml: str | None
+    subjects: tuple[str, ...] = ()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def parse_name_status(text: str) -> tuple[Change, ...]:
+    changes = []
+    for line in text.splitlines():
+        if not line:
+            continue
+        fields = line.split("\t")
+        status = fields[0]
+        if status.startswith(("R", "C")):
+            if len(fields) != 3:
+                raise ValueError(f"invalid rename status line: {line!r}")
+            changes.append(Change(status, fields[1], fields[2]))
+        else:
+            if len(fields) != 2:
+                raise ValueError(f"invalid name-status line: {line!r}")
+            changes.append(Change(status, None, fields[1]))
+    return tuple(changes)
+
+
+def git_output(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or "git command failed"
+        raise RuntimeError(detail)
+    return result.stdout
+
+
+def split_range(value: str) -> tuple[str, str]:
+    base, separator, head = value.partition("..")
+    if separator != ".." or not base or not head:
+        raise ValueError("--range must be BASE..HEAD")
+    return base, head
+
+
+def load_git_inputs(title: str, body: str, revision_range: str) -> Inputs:
+    base, _ = split_range(revision_range)
+    changes = parse_name_status(git_output("diff", "--name-status", "-M", revision_range))
+    commits = git_output("log", "--format=%B", revision_range)
+    subjects = tuple(line for line in git_output("log", "--format=%s", revision_range).splitlines() if line)
+    overlay_changed = any(OVERLAY_TOML in change.paths for change in changes)
+    overlay_toml = read_text(Path(OVERLAY_TOML)) if overlay_changed else None
+    base_overlay_toml = (
+        git_output("show", f"{base}:{OVERLAY_TOML}") if overlay_changed else None
+    )
+    return Inputs(title, body, changes, commits, overlay_toml, base_overlay_toml, subjects)
+
+
+def load_fixture_inputs(directory: Path) -> Inputs:
+    changes = parse_name_status(read_text(directory / "diff.name-status"))
+    overlay = directory / "overlay.toml"
+    base_overlay = directory / "overlay.base.toml"
+    return Inputs(
+        read_text(directory / "title.txt").rstrip("\n"),
+        read_text(directory / "body.md"),
+        changes,
+        read_text(directory / "commits.txt"),
+        read_text(overlay) if overlay.exists() else None,
+        read_text(base_overlay) if base_overlay.exists() else None,
+        tuple(
+            line for line in read_text(directory / "commits.txt").splitlines()[:1] if line
+        ),
+    )
+
+
+def package_path(path: str, filename: str) -> str | None:
+    parts = path.split("/")
+    if len(parts) != 3 or parts[2] != filename:
+        return None
+    return "/".join(parts[:2])
+
+
+def is_ebuild_path(path: str) -> bool:
+    return bool(PACKAGE_FILE_RE.fullmatch(path) and path.endswith(".ebuild"))
+
+
+def overlay_keys(text: str | None) -> tuple[str, ...]:
+    return tuple(TABLE_RE.findall(text or ""))
+
+
+def check_title_format(inputs: Inputs) -> Iterable[str]:
+    # AGENTS.md § Commit and PR Text: the PR title is the commit subject verbatim;
+    # subject format and length are pkgcheck's GitCommitMessageCheck job
+    title = inputs.title.strip()
+    if "\n" in inputs.title.strip("\n"):
+        yield "title must be one line"
+        return
+    if inputs.subjects and title not in inputs.subjects:
+        yield "title must equal the subject of the commit carrying the main change"
+
+
+def is_routine_bump(changes: tuple[Change, ...]) -> bool:
+    if not changes:
+        return False
+    has_manifest = False
+    has_rename = False
+    for change in changes:
+        manifest_package = package_path(change.new_path, "Manifest")
+        if change.status == "M" and manifest_package:
+            has_manifest = True
+            continue
+        # only an unchanged ebuild (R100) is routine; an edited one needs a reason
+        if (
+            change.status == "R100"
+            and change.old_path is not None
+            and is_ebuild_path(change.old_path)
+            and is_ebuild_path(change.new_path)
+            and Path(change.old_path).parent == Path(change.new_path).parent
+        ):
+            has_rename = True
+            continue
+        return False
+    return has_manifest and has_rename
+
+
+def body_before_template(body: str) -> str:
+    return TEMPLATE_RE.split(body, maxsplit=1)[0]
+
+
+def check_routine_bump_body(inputs: Inputs) -> Iterable[str]:
+    if not is_routine_bump(inputs.changes):
+        return
+    lines = [line.strip() for line in body_before_template(inputs.body).splitlines() if line.strip()]
+    if not lines or any(re.fullmatch(r"Closes #\d+", line) is None for line in lines):
+        yield "routine bump body must contain only bare Closes #<n> lines"
+
+
+def check_no_ai_attribution(inputs: Inputs) -> Iterable[str]:
+    for label, text in (("PR body", inputs.body), ("commit message", inputs.commits)):
+        for line in text.splitlines():
+            if AI_ATTRIBUTION_RE.search(line):
+                yield f"{label} contains forbidden AI attribution"
+    for line in inputs.commits.splitlines():
+        if NOREPLY_SIGNOFF_RE.search(line):
+            yield "commit message uses a GitHub noreply Signed-off-by address"
+
+
+def check_closes_format(inputs: Inputs) -> Iterable[str]:
+    for text in (inputs.body, inputs.commits):
+        for line in text.splitlines():
+            if OVERLAY_ISSUE_URL in line:
+                yield "overlay issue links must use bare Closes #<n>"
+            if re.search(r"\bFixes\s+#\d+\b", line, re.IGNORECASE):
+                yield "use Closes #<n>, not Fixes #<n>"
+            if re.match(r"^Bug:\s*", line, re.IGNORECASE):
+                yield "issue references must use bare Closes #<n>"
+            if re.search(r"\bCloses:\s*https://bugs\.gentoo\.org", line, re.IGNORECASE):
+                yield "issue references must use bare Closes #<n>"
+            if re.search(r"\bCloses\s+#\d+\b", line, re.IGNORECASE) and not re.fullmatch(
+                r"Closes #\d+", line.strip(), re.IGNORECASE
+            ):
+                yield "issue references must use bare Closes #<n>"
+
+
+def new_package_paths(changes: tuple[Change, ...]) -> tuple[str, ...]:
+    packages = []
+    for change in changes:
+        package = package_path(change.new_path, "metadata.xml")
+        if change.status == "A" and package and package.split("/", 1)[0] not in {
+            "acct-group",
+            "acct-user",
+            "virtual",
+        }:
+            packages.append(package)
+    return tuple(packages)
+
+
+def check_new_package_nvchecker(inputs: Inputs) -> Iterable[str]:
+    changed_overlay = any(OVERLAY_TOML in change.paths for change in inputs.changes)
+    keys = set(overlay_keys(inputs.overlay_toml))
+    for package in new_package_paths(inputs.changes):
+        if not changed_overlay or package not in keys:
+            yield f"new package {package} lacks an overlay.toml entry in this diff"
+
+
+def check_overlay_toml_sorted(inputs: Inputs) -> Iterable[str]:
+    if not any(OVERLAY_TOML in change.paths for change in inputs.changes):
+        return
+    keys = overlay_keys(inputs.overlay_toml)
+    existing = set(overlay_keys(inputs.base_overlay_toml))
+    for index, key in enumerate(keys):
+        if key in existing:
+            continue
+        previous = keys[index - 1] if index else None
+        following = keys[index + 1] if index + 1 < len(keys) else None
+        if (previous is not None and previous > key) or (
+            following is not None and key > following
+        ):
+            yield f'new key "{key}" is not sorted between its adjacent keys'
+
+
+def check_workflow_change(inputs: Inputs) -> Iterable[str]:
+    if any(
+        path.startswith(".github/workflows/") and path.endswith(".yml")
+        for change in inputs.changes
+        for path in change.paths
+    ):
+        yield "workflow files changed; needs a maintainer to review"
+
+
+def check_checklist(inputs: Inputs) -> Iterable[str]:
+    if re.search(r"^- \[ \] I have run", inputs.body, re.MULTILINE):
+        yield "pkgcheck checklist item is not checked"
+
+
+CHECKS: tuple[tuple[str, Callable[[Inputs], Iterable[str]]], ...] = (
+    ("title-format", check_title_format),
+    ("routine-bump-body", check_routine_bump_body),
+    ("no-ai-attribution", check_no_ai_attribution),
+    ("closes-format", check_closes_format),
+    ("new-package-nvchecker", check_new_package_nvchecker),
+    ("overlay-toml-sorted", check_overlay_toml_sorted),
+    ("workflow-change", check_workflow_change),
+    ("checklist", check_checklist),
+)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check deterministic gentoo-zh pull-request rules.",
+        epilog="Checks: " + ", ".join(CHECK_IDS),
+    )
+    parser.add_argument("--title", help="pull-request title")
+    parser.add_argument("--body", help="pull-request body")
+    parser.add_argument("--range", dest="revision_range", help="commit range as BASE..HEAD")
+    parser.add_argument("--fixture", type=Path, help="read test inputs from a fixture directory")
+    parser.add_argument(
+        "--skip",
+        choices=CHECK_IDS,
+        action="append",
+        default=[],
+        metavar="CHECK-ID",
+        help="disable a check; may be repeated",
+    )
+    args = parser.parse_args(argv)
+    if args.fixture is None and (args.title is None or args.body is None or args.revision_range is None):
+        parser.error("--title, --body, and --range are required without --fixture")
+    if args.fixture is not None and any(
+        value is not None for value in (args.title, args.body, args.revision_range)
+    ):
+        parser.error("--fixture cannot be combined with --title, --body, or --range")
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        inputs = load_fixture_inputs(args.fixture) if args.fixture else load_git_inputs(
+            args.title, args.body, args.revision_range
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"pr-lint: {error}", file=sys.stderr)
+        return 2
+
+    failed = False
+    skipped = set(args.skip)
+    for check_id, check in CHECKS:
+        if check_id in skipped:
+            continue
+        for message in check(inputs):
+            print(f"{check_id}: {message}")
+            failed = failed or check_id != "workflow-change"
+    return int(failed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tests/pr-lint/ai-attribution/body.md
+++ b/scripts/tests/pr-lint/ai-attribution/body.md
@@ -1,0 +1,5 @@
+Generated with Codex
+
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/ai-attribution/commits.txt
+++ b/scripts/tests/pr-lint/ai-attribution/commits.txt
@@ -1,0 +1,4 @@
+app-misc/example: update metadata
+
+Co-Authored-By: Claude <claude@example.org>
+Signed-off-by: Bot <bot@users.noreply.github.com>

--- a/scripts/tests/pr-lint/ai-attribution/diff.name-status
+++ b/scripts/tests/pr-lint/ai-attribution/diff.name-status
@@ -1,0 +1,1 @@
+M	app-misc/example/metadata.xml

--- a/scripts/tests/pr-lint/ai-attribution/expected.txt
+++ b/scripts/tests/pr-lint/ai-attribution/expected.txt
@@ -1,0 +1,3 @@
+no-ai-attribution: PR body contains forbidden AI attribution
+no-ai-attribution: commit message contains forbidden AI attribution
+no-ai-attribution: commit message uses a GitHub noreply Signed-off-by address

--- a/scripts/tests/pr-lint/ai-attribution/title.txt
+++ b/scripts/tests/pr-lint/ai-attribution/title.txt
@@ -1,0 +1,1 @@
+app-misc/example: update metadata

--- a/scripts/tests/pr-lint/edited-ebuild-rename/body.md
+++ b/scripts/tests/pr-lint/edited-ebuild-rename/body.md
@@ -1,0 +1,8 @@
+Closes #13316
+
+因为上游换了 build id，所以 MY_BUILD 跟着改。
+
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
+- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

--- a/scripts/tests/pr-lint/edited-ebuild-rename/commits.txt
+++ b/scripts/tests/pr-lint/edited-ebuild-rename/commits.txt
@@ -1,0 +1,3 @@
+app-misc/example: add 1.1
+
+Signed-off-by: Example Maintainer <maintainer@example.org>

--- a/scripts/tests/pr-lint/edited-ebuild-rename/diff.name-status
+++ b/scripts/tests/pr-lint/edited-ebuild-rename/diff.name-status
@@ -1,0 +1,2 @@
+M	app-misc/example/Manifest
+R080	app-misc/example/example-1.0.ebuild	app-misc/example/example-1.1.ebuild

--- a/scripts/tests/pr-lint/edited-ebuild-rename/title.txt
+++ b/scripts/tests/pr-lint/edited-ebuild-rename/title.txt
@@ -1,0 +1,1 @@
+app-misc/example: add 1.1

--- a/scripts/tests/pr-lint/issue-link/body.md
+++ b/scripts/tests/pr-lint/issue-link/body.md
@@ -1,0 +1,5 @@
+https://github.com/gentoo-zh/overlay/issues/123
+
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/issue-link/commits.txt
+++ b/scripts/tests/pr-lint/issue-link/commits.txt
@@ -1,0 +1,1 @@
+app-misc/example: update metadata

--- a/scripts/tests/pr-lint/issue-link/diff.name-status
+++ b/scripts/tests/pr-lint/issue-link/diff.name-status
@@ -1,0 +1,1 @@
+M	app-misc/example/metadata.xml

--- a/scripts/tests/pr-lint/issue-link/expected.txt
+++ b/scripts/tests/pr-lint/issue-link/expected.txt
@@ -1,0 +1,1 @@
+closes-format: overlay issue links must use bare Closes #<n>

--- a/scripts/tests/pr-lint/issue-link/title.txt
+++ b/scripts/tests/pr-lint/issue-link/title.txt
@@ -1,0 +1,1 @@
+app-misc/example: update metadata

--- a/scripts/tests/pr-lint/new-package-missing-overlay/body.md
+++ b/scripts/tests/pr-lint/new-package-missing-overlay/body.md
@@ -1,0 +1,3 @@
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/new-package-missing-overlay/commits.txt
+++ b/scripts/tests/pr-lint/new-package-missing-overlay/commits.txt
@@ -1,0 +1,1 @@
+app-misc/new-tool: new package, add 1.0

--- a/scripts/tests/pr-lint/new-package-missing-overlay/diff.name-status
+++ b/scripts/tests/pr-lint/new-package-missing-overlay/diff.name-status
@@ -1,0 +1,1 @@
+A	app-misc/new-tool/metadata.xml

--- a/scripts/tests/pr-lint/new-package-missing-overlay/expected.txt
+++ b/scripts/tests/pr-lint/new-package-missing-overlay/expected.txt
@@ -1,0 +1,1 @@
+new-package-nvchecker: new package app-misc/new-tool lacks an overlay.toml entry in this diff

--- a/scripts/tests/pr-lint/new-package-missing-overlay/title.txt
+++ b/scripts/tests/pr-lint/new-package-missing-overlay/title.txt
@@ -1,0 +1,1 @@
+app-misc/new-tool: new package, add 1.0

--- a/scripts/tests/pr-lint/new-package-with-overlay/body.md
+++ b/scripts/tests/pr-lint/new-package-with-overlay/body.md
@@ -1,0 +1,3 @@
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/new-package-with-overlay/commits.txt
+++ b/scripts/tests/pr-lint/new-package-with-overlay/commits.txt
@@ -1,0 +1,1 @@
+app-misc/new-tool: new package, add 1.0

--- a/scripts/tests/pr-lint/new-package-with-overlay/diff.name-status
+++ b/scripts/tests/pr-lint/new-package-with-overlay/diff.name-status
@@ -1,0 +1,2 @@
+A	app-misc/new-tool/metadata.xml
+M	.github/workflows/overlay.toml

--- a/scripts/tests/pr-lint/new-package-with-overlay/overlay.toml
+++ b/scripts/tests/pr-lint/new-package-with-overlay/overlay.toml
@@ -1,0 +1,2 @@
+["app-misc/new-tool"]
+source = "github"

--- a/scripts/tests/pr-lint/new-package-with-overlay/title.txt
+++ b/scripts/tests/pr-lint/new-package-with-overlay/title.txt
@@ -1,0 +1,1 @@
+app-misc/new-tool: new package, add 1.0

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/body.md
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/body.md
@@ -1,0 +1,3 @@
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/commits.txt
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/commits.txt
@@ -1,0 +1,1 @@
+.github/workflows: sort tracker entries

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/diff.name-status
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/diff.name-status
@@ -1,0 +1,1 @@
+M	.github/workflows/overlay.toml

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/expected.txt
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/expected.txt
@@ -1,0 +1,1 @@
+overlay-toml-sorted: new key "app-misc/b" is not sorted between its adjacent keys

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/overlay.base.toml
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/overlay.base.toml
@@ -1,0 +1,2 @@
+["app-misc/a"]
+["app-misc/c"]

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/overlay.toml
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/overlay.toml
@@ -1,0 +1,3 @@
+["app-misc/a"]
+["app-misc/c"]
+["app-misc/b"]

--- a/scripts/tests/pr-lint/overlay-toml-unsorted/title.txt
+++ b/scripts/tests/pr-lint/overlay-toml-unsorted/title.txt
@@ -1,0 +1,1 @@
+.github/workflows: sort tracker entries

--- a/scripts/tests/pr-lint/routine-bump-extra-body/body.md
+++ b/scripts/tests/pr-lint/routine-bump-extra-body/body.md
@@ -1,0 +1,7 @@
+Update the package.
+
+Closes #123
+
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/routine-bump-extra-body/commits.txt
+++ b/scripts/tests/pr-lint/routine-bump-extra-body/commits.txt
@@ -1,0 +1,1 @@
+app-misc/example: add 1.1

--- a/scripts/tests/pr-lint/routine-bump-extra-body/diff.name-status
+++ b/scripts/tests/pr-lint/routine-bump-extra-body/diff.name-status
@@ -1,0 +1,2 @@
+M	app-misc/example/Manifest
+R100	app-misc/example/example-1.0.ebuild	app-misc/example/example-1.1.ebuild

--- a/scripts/tests/pr-lint/routine-bump-extra-body/expected.txt
+++ b/scripts/tests/pr-lint/routine-bump-extra-body/expected.txt
@@ -1,0 +1,1 @@
+routine-bump-body: routine bump body must contain only bare Closes #<n> lines

--- a/scripts/tests/pr-lint/routine-bump-extra-body/title.txt
+++ b/scripts/tests/pr-lint/routine-bump-extra-body/title.txt
@@ -1,0 +1,1 @@
+app-misc/example: add 1.1

--- a/scripts/tests/pr-lint/routine-bump-pass/body.md
+++ b/scripts/tests/pr-lint/routine-bump-pass/body.md
@@ -1,0 +1,7 @@
+Closes #123
+
+---
+
+Please check all the boxes that apply:
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/routine-bump-pass/commits.txt
+++ b/scripts/tests/pr-lint/routine-bump-pass/commits.txt
@@ -1,0 +1,3 @@
+app-misc/example: add 1.1
+
+Signed-off-by: Example Maintainer <maintainer@example.org>

--- a/scripts/tests/pr-lint/routine-bump-pass/diff.name-status
+++ b/scripts/tests/pr-lint/routine-bump-pass/diff.name-status
@@ -1,0 +1,2 @@
+M	app-misc/example/Manifest
+R100	app-misc/example/example-1.0.ebuild	app-misc/example/example-1.1.ebuild

--- a/scripts/tests/pr-lint/routine-bump-pass/title.txt
+++ b/scripts/tests/pr-lint/routine-bump-pass/title.txt
@@ -1,0 +1,1 @@
+app-misc/example: add 1.1

--- a/scripts/tests/pr-lint/run.sh
+++ b/scripts/tests/pr-lint/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -u
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+status=0
+
+for fixture in "$root/scripts/tests/pr-lint"/*; do
+    [ -d "$fixture" ] || continue
+    actual=$(mktemp)
+    result=0
+    python3 "$root/scripts/pr-lint.py" --fixture "$fixture" > "$actual" || result=$?
+
+    if ! diff -u "$fixture/expected.txt" "$actual"; then
+        status=1
+    fi
+
+    case "$(cat "$fixture/expected.txt")" in
+        ""|"workflow-change: workflow files changed; needs a maintainer to review")
+            expected_status=0
+            ;;
+        *)
+            expected_status=1
+            ;;
+    esac
+    if [ "$result" -ne "$expected_status" ]; then
+        printf '%s: expected exit %s, got %s\n' "${fixture##*/}" "$expected_status" "$result" >&2
+        status=1
+    fi
+    rm -f "$actual"
+done
+
+exit "$status"

--- a/scripts/tests/pr-lint/title-mismatch/body.md
+++ b/scripts/tests/pr-lint/title-mismatch/body.md
@@ -1,0 +1,3 @@
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/title-mismatch/commits.txt
+++ b/scripts/tests/pr-lint/title-mismatch/commits.txt
@@ -1,0 +1,1 @@
+app-misc/example: update metadata

--- a/scripts/tests/pr-lint/title-mismatch/diff.name-status
+++ b/scripts/tests/pr-lint/title-mismatch/diff.name-status
@@ -1,0 +1,1 @@
+M	app-misc/example/metadata.xml

--- a/scripts/tests/pr-lint/title-mismatch/expected.txt
+++ b/scripts/tests/pr-lint/title-mismatch/expected.txt
@@ -1,0 +1,1 @@
+title-format: title must equal the subject of the commit carrying the main change

--- a/scripts/tests/pr-lint/title-mismatch/title.txt
+++ b/scripts/tests/pr-lint/title-mismatch/title.txt
@@ -1,0 +1,1 @@
+Bump xreader

--- a/scripts/tests/pr-lint/unchecked-checklist/body.md
+++ b/scripts/tests/pr-lint/unchecked-checklist/body.md
@@ -1,0 +1,3 @@
+---
+
+- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/unchecked-checklist/commits.txt
+++ b/scripts/tests/pr-lint/unchecked-checklist/commits.txt
@@ -1,0 +1,1 @@
+app-misc/example: update metadata

--- a/scripts/tests/pr-lint/unchecked-checklist/diff.name-status
+++ b/scripts/tests/pr-lint/unchecked-checklist/diff.name-status
@@ -1,0 +1,1 @@
+M	app-misc/example/metadata.xml

--- a/scripts/tests/pr-lint/unchecked-checklist/expected.txt
+++ b/scripts/tests/pr-lint/unchecked-checklist/expected.txt
@@ -1,0 +1,1 @@
+checklist: pkgcheck checklist item is not checked

--- a/scripts/tests/pr-lint/unchecked-checklist/title.txt
+++ b/scripts/tests/pr-lint/unchecked-checklist/title.txt
@@ -1,0 +1,1 @@
+app-misc/example: update metadata

--- a/scripts/tests/pr-lint/workflow-change-warning/body.md
+++ b/scripts/tests/pr-lint/workflow-change-warning/body.md
@@ -1,0 +1,3 @@
+---
+
+- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--- a/scripts/tests/pr-lint/workflow-change-warning/commits.txt
+++ b/scripts/tests/pr-lint/workflow-change-warning/commits.txt
@@ -1,0 +1,1 @@
+.github/workflows: run lint

--- a/scripts/tests/pr-lint/workflow-change-warning/diff.name-status
+++ b/scripts/tests/pr-lint/workflow-change-warning/diff.name-status
@@ -1,0 +1,1 @@
+M	.github/workflows/pkgcheck.yml

--- a/scripts/tests/pr-lint/workflow-change-warning/expected.txt
+++ b/scripts/tests/pr-lint/workflow-change-warning/expected.txt
@@ -1,0 +1,1 @@
+workflow-change: workflow files changed; needs a maintainer to review

--- a/scripts/tests/pr-lint/workflow-change-warning/title.txt
+++ b/scripts/tests/pr-lint/workflow-change-warning/title.txt
@@ -1,0 +1,1 @@
+.github/workflows: run lint


### PR DESCRIPTION
把 AGENTS.md 里能机械判定的规则交给 CI；#13102 的第一步，不改 AGENTS.md。

1. 因为 pkgcheck 的 `GitCommitMessageCheck`／`GitPkgCommitsCheck` 已经检查 commit subject 的 `category/package:` 前缀、69 字上限、`Signed-off-by` 与作者一致（本机试过 noreply 地址会报 `MissingSignOff`），所以在 pkgcheck 的 report job 里加 `--commits` 扫描 PR 自己的 commit，结果并入现有评论，不重写这些检查。
2. 因为 pkgcheck 不看 PR 标题和正文，所以加 `scripts/pr-lint.py`（标准库）：标题等于主 commit 的 subject（AGENTS.md「Take pkgdev's final English subject verbatim」）、routine bump（只有 Manifest 改动 + ebuild 原样 rename）正文只准 `Closes #N`、AI 署名与 noreply 邮箱、overlay issue 只能裸写 `Closes #N`、新包必须同 PR 带 `overlay.toml` 条目且 key 有序、改 workflow 打标记要人审、模板勾框没勾。每项一个 check-id，可 `--skip`；11 个 fixture，`scripts/tests/pr-lint/run.sh` 跑全部。
3. 因为 workflow 只读 `pull_request` 事件里的标题正文并跑标准库脚本，所以权限只有 `contents: read` 和 `pull-requests: read`，不用第三方 action。

拿这两天的 PR 对过：#13331 原来那版带测试报告的正文会红，改成只剩 `Closes #13316` 绿；#13352 去掉 overlay.toml 改动会红。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [ ] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
